### PR TITLE
Fix: Matrix rain — update emoji set + randomize frequency to 1–5%

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -11,7 +11,8 @@ window.APC.boot = (function () {
 
   const MATRIX_COLOR = '#00FF41';
   const FONT_SIZE = 14;
-  const MATRIX_EMOJI_FREQUENCY = 0.065; // 6.5% — midpoint of spec range 5–8%
+  const MATRIX_EMOJI_FREQUENCY_MIN = 0.01; // emoji appears in 1–5% of characters,
+  const MATRIX_EMOJI_FREQUENCY_MAX = 0.05; // re-rolled per draw call
   const FADE_DURATION_MS = 600;
 
   const BOOT_BLOCK_COUNT = 20;
@@ -27,13 +28,11 @@ window.APC.boot = (function () {
     '@#$%*+-=:<>/\\|'
   ];
 
-  // Exact emoji list from CLAUDE.md spec — do not modify.
+  // Curated emoji set — interests and themes personal to Atsushi's PC.
   const MATRIX_EMOJIS = [
-    '🤣', '🤔', '😍', '😂', '🥰', '😘', '😊', '😎', '🙏', '💪',
-    '👍', '✨', '🔥', '🤗', '🥲', '🙈', '🙉', '🙊', '💯', '🎉',
-    '💩', '🤪', '😳', '🥴', '🧐', '😮', '🫡', '🫠', '😌', '😏',
-    '😶', '😅', '😁', '🥸', '😒', '😜', '😝', '🤭', '🤐', '🫢',
-    '🫣', '🤫', '🤥', '💤'
+    '🎾', '⛳', '🎣', '🍜', '🍕', '🎮', '✈️', '🌍', '🌱',
+    '💾', '🖥️', '🔌', '🛠️', '🎭', '🧩', '🧠', '⚙️', '🔍',
+    '♟️', '🌉', '📦', '🧨', '📊', '🧭'
   ];
 
   // --- Module state ----------------------------------------------------
@@ -119,7 +118,10 @@ window.APC.boot = (function () {
 
     for (let i = 0; i < columns.length; i++) {
       const col = columns[i];
-      const isEmoji = Math.random() < MATRIX_EMOJI_FREQUENCY;
+      // Frequency re-rolled per character: random threshold between 1–5%.
+      const emojiThreshold = MATRIX_EMOJI_FREQUENCY_MIN +
+        Math.random() * (MATRIX_EMOJI_FREQUENCY_MAX - MATRIX_EMOJI_FREQUENCY_MIN);
+      const isEmoji = Math.random() < emojiThreshold;
 
       if (isEmoji) {
         // CSS emoji color filter hack: collapses emoji's native colors to black


### PR DESCRIPTION
## Summary

- Replaces 44 generic face/reaction emojis with 24 curated emojis personal to Atsushi's PC
- Changes frequency from a fixed 6.5% constant to per-character random 1–5%

## Emoji changes

**Removed:** generic faces, reactions, animals (🤣 😍 💩 🙈 etc.)

**New set (24):** 🎾 ⛳ 🎣 🍜 🍕 🎮 ✈️ 🌍 🌱 💾 🖥️ 🔌 🛠️ 🎭 🧩 🧠 ⚙️ 🔍 ♟️ 🌉 📦 🧨 📊 🧭

## Frequency change

| Before | After |
|--------|-------|
| Fixed `MATRIX_EMOJI_FREQUENCY = 0.065` (always 6.5%) | `MATRIX_EMOJI_FREQUENCY_MIN = 0.01` / `MAX = 0.05` — re-rolled per character draw call |

Emoji density is now sparser and more varied — never a fixed rate.

## Test plan

- [ ] Matrix rain shows new emoji set (sports, food, tech, travel themes)
- [ ] No old face/reaction emojis visible
- [ ] Emoji density feels sparse — noticeably less frequent than before
- [ ] Emoji CSS filter still applies correctly (all render in `#00FF41` green)
- [ ] No console errors

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)