### PR TITLE
Fix: mobile interstitial false positive on laptop Safari

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -42,9 +42,12 @@ window.APC.boot = (function () {
   // --- Mobile detection ----------------------------------------------------
 
   function isMobileOrTouch() {
-    return window.innerWidth < 1024 ||
-      'ontouchstart' in window ||
-      navigator.maxTouchPoints > 0;
+    // Both conditions must be true: genuine touch hardware (maxTouchPoints > 1)
+    // AND a physically small screen (screen.width, not window.innerWidth).
+    // Using screen.width prevents false positives on laptops with small windows.
+    // maxTouchPoints > 1 (not > 0) excludes laptops that report a single
+    // touch point for Force Touch / precision touchpad on macOS.
+    return navigator.maxTouchPoints > 1 && screen.width < 1024;
   }
 
   function showMobileInterstitial() {


### PR DESCRIPTION
## Problem

The interstitial was showing on a laptop Safari browser at 856×814px window size. The old detection used OR logic across three unreliable signals:

- `window.innerWidth < 1024` — triggers on any small browser window, not just mobile screens
- `'ontouchstart' in window` — true on some desktop Safari builds
- `navigator.maxTouchPoints > 0` — true on Macs (Force Touch / precision touchpad reports 1)

## Fix

Both conditions must now be true simultaneously:

```js
return navigator.maxTouchPoints > 1 && screen.width < 1024;
```

- `screen.width` is the physical display width — unaffected by window resizing
- `maxTouchPoints > 1` requires genuine multi-touch hardware; excludes Mac trackpads (report 1)

A MacBook with a 1440px screen at an 856px window: `screen.width` is ~1440, so the interstitial never fires.

## Test plan

- [ ] Laptop Safari at any window size: no interstitial
- [ ] Laptop Chrome/Firefox at any window size: no interstitial
- [ ] iPhone Safari (375px screen): interstitial shows
- [ ] iPad (768px screen): interstitial shows
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)