### PR TITLE
Feature: Matrix rain — IBM Aptiva SE7 identity lines

### DIFF
--- a/css/boot.css
+++ b/css/boot.css
@@ -66,6 +66,12 @@
   animation: cursor-blink 530ms step-end infinite;
 }
 
+/* --- Hidden until identity line sequence completes --------- */
+
+#gate-prompt.gate-prompt--hidden {
+  visibility: hidden;
+}
+
 /* --- Fade-out transition triggered by JS ------------------- */
 
 #gate-screen.gate-screen--fade {

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
   <div id="gate-screen" aria-label="System startup screen">
     <canvas id="matrix-canvas" aria-hidden="true"></canvas>
     <div id="gate-prompt"
+         class="gate-prompt--hidden"
          role="button"
          tabindex="0"
          aria-label="Click or press any key to start Atsushi's PC">

--- a/js/boot.js
+++ b/js/boot.js
@@ -37,6 +37,17 @@ window.APC.boot = (function () {
   let startupAudio;
   let hasStarted = false;
 
+  // Identity lines state — typed portions redrawn each frame at full brightness.
+  const IDENTITY_LINE_1 = '> initializing experience on IBM Aptiva SE7';
+  const IDENTITY_LINE_2 = '> $3,299 in 1998. the fastest consumer PC money could buy.';
+
+  let identityPhase = 'waiting'; // waiting | line1 | gap | line2 | pause | done
+  let identityTyped1 = '';
+  let identityTyped2 = '';
+  let identityX = 0;
+  let identityY1 = 0;
+  let identityY2 = 0;
+
   // --- Public API ------------------------------------------------------
 
   // --- Mobile detection ----------------------------------------------------
@@ -206,6 +217,10 @@ window.APC.boot = (function () {
     resizeCanvas();
     animFrame = requestAnimationFrame(drawFrame);
 
+    // Schedule identity lines to begin after rain has established itself.
+    // Prompt stays hidden until the full sequence completes.
+    setTimeout(startIdentityLines, window.APC.timing.MATRIX_IDENTITY_START_MS);
+
     // Gate screen catches all clicks anywhere on screen.
     const gate = document.getElementById('gate-screen');
     gate.addEventListener('click', onGateInteract);
@@ -218,6 +233,64 @@ window.APC.boot = (function () {
 
     // Auto-focus the prompt so keyboard users can interact immediately.
     document.getElementById('gate-prompt').focus();
+  }
+
+  // --- Identity lines --------------------------------------------------
+  //
+  // Two lines type character-by-character onto the canvas at 40–60ms/char,
+  // appearing as part of the rain. Both are redrawn at full brightness every
+  // frame so the 0.15 fade overlay doesn't dim them while they're typing.
+  // All timeouts abort immediately if the user has already interacted.
+
+  function startIdentityLines() {
+    if (hasStarted) { return; }
+    const rows = Math.floor(canvas.height / FONT_SIZE);
+    // Anchor roughly 42% down the screen — prompt at 50% will sit below.
+    const anchorRow = Math.floor(rows * 0.42);
+    identityX  = 2 * FONT_SIZE;
+    identityY1 = (anchorRow + 1) * FONT_SIZE;
+    identityY2 = (anchorRow + 2) * FONT_SIZE;
+    identityPhase = 'line1';
+    typeNextChar();
+  }
+
+  function typeNextChar() {
+    if (hasStarted) { return; }
+    const t = window.APC.timing;
+
+    if (identityPhase === 'line1') {
+      const idx = identityTyped1.length;
+      if (idx < IDENTITY_LINE_1.length) {
+        identityTyped1 += IDENTITY_LINE_1[idx];
+        setTimeout(typeNextChar, t.rand(t.MATRIX_IDENTITY_CHAR_MIN_MS, t.MATRIX_IDENTITY_CHAR_MAX_MS));
+      } else {
+        // Line 1 complete — pause before line 2.
+        identityPhase = 'gap';
+        setTimeout(function () {
+          if (hasStarted) { return; }
+          identityPhase = 'line2';
+          typeNextChar();
+        }, t.MATRIX_IDENTITY_LINE_GAP_MS);
+      }
+
+    } else if (identityPhase === 'line2') {
+      const idx = identityTyped2.length;
+      if (idx < IDENTITY_LINE_2.length) {
+        identityTyped2 += IDENTITY_LINE_2[idx];
+        setTimeout(typeNextChar, t.rand(t.MATRIX_IDENTITY_CHAR_MIN_MS, t.MATRIX_IDENTITY_CHAR_MAX_MS));
+      } else {
+        // Line 2 complete — pause then reveal prompt.
+        identityPhase = 'pause';
+        setTimeout(revealPrompt, t.MATRIX_IDENTITY_PROMPT_GAP_MS);
+      }
+    }
+  }
+
+  function revealPrompt() {
+    if (hasStarted) { return; }
+    identityPhase = 'done';
+    const prompt = document.getElementById('gate-prompt');
+    if (prompt) { prompt.classList.remove('gate-prompt--hidden'); }
   }
 
   // --- Canvas setup ----------------------------------------------------
@@ -317,6 +390,19 @@ window.APC.boot = (function () {
       }
 
       col.nextCharTime = now + col.charDelay;
+    }
+
+    // Redraw typed identity lines at full brightness each frame so the fade
+    // overlay doesn't dim them while they're still being typed.
+    if (identityPhase !== 'waiting') {
+      ctx.font = FONT_SIZE + 'px "Courier New", monospace';
+      ctx.fillStyle = MATRIX_COLOR;
+      if (identityTyped1) {
+        ctx.fillText(identityTyped1, identityX, identityY1);
+      }
+      if (identityTyped2) {
+        ctx.fillText(identityTyped2, identityX, identityY2);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Implements the IBM Aptiva identity line sequence that appears during the Matrix rain gate screen, per the CLAUDE.md spec.

**Sequence:**
1. Rain runs for 2 seconds
2. Line 1 types character-by-character at 40–60ms/char: `> initializing experience on IBM Aptiva SE7`
3. 600ms pause
4. Line 2 types: `> $3,299 in 1998. the fastest consumer PC money could buy.`
5. 1000ms pause
6. `C:\> press any key to continue_` prompt revealed with blinking cursor

**Technical approach:**
- Lines drawn directly on the canvas (`ctx.fillText`) — same Courier New font and size as the rain
- Redrawn at full brightness every rAF frame so the `0.15` fade overlay doesn't dim them mid-type
- All timing from existing `win98-timing.js` `MATRIX_IDENTITY_*` tokens — no new hardcoded values
- `#gate-prompt` starts with `gate-prompt--hidden` class (`visibility: hidden`) and is revealed only after the full sequence completes
- All `setTimeout` callbacks guard on `hasStarted` — clicking mid-sequence aborts cleanly

## Test plan

- [ ] Rain runs for ~2 seconds before any text appears
- [ ] Line 1 types character-by-character (not all at once)
- [ ] ~600ms visible pause between line 1 and line 2
- [ ] Line 2 types character-by-character
- [ ] ~1000ms pause then `C:\> press any key to continue_` appears with blinking cursor
- [ ] Clicking or pressing a key at any point during the sequence starts the boot immediately — no stuck state
- [ ] Session restore (refresh after boot): gate never shows, prompt hidden state irrelevant
- [ ] No console errors

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)