### PR TITLE
Feature: NetEscape Protected Path latency + status bar sequence

### DIFF
--- a/js/netescape.js
+++ b/js/netescape.js
@@ -79,6 +79,10 @@ window.APC.netescape = (function () {
   // dialog. Cancelled whenever the user navigates to a known URL.
   let freezeTimer = null;
 
+  // Page-load delay timers — cancelled whenever a new navigation begins.
+  let pageLoadTimer    = null;  // full delay before renderPage fires
+  let pageLoadMidTimer = null;  // mid-point timer for "Transferring data..." status
+
   // --- Public API ------------------------------------------------------
 
   // connect(onComplete) — plays the dial-up sequence and sets isConnected.
@@ -309,21 +313,23 @@ window.APC.netescape = (function () {
   function goBack() {
     if (navIndex <= 0) { return; }
     navIndex--;
-    const url = navHistory[navIndex];
+    var url = navHistory[navIndex];
     currentUrl = url;
     if (addressInput) { addressInput.value = url; }
-    renderPage(PAGE_ROUTES[url] || 'home');
     updateNavButtons();
+    var t = window.APC.timing;
+    startPageLoad(url, PAGE_ROUTES[url] || 'home', t.rand(t.NE_BACK_FWD_MIN_MS, t.NE_BACK_FWD_MAX_MS));
   }
 
   function goForward() {
     if (navIndex >= navHistory.length - 1) { return; }
     navIndex++;
-    const url = navHistory[navIndex];
+    var url = navHistory[navIndex];
     currentUrl = url;
     if (addressInput) { addressInput.value = url; }
-    renderPage(PAGE_ROUTES[url] || 'home');
     updateNavButtons();
+    var t = window.APC.timing;
+    startPageLoad(url, PAGE_ROUTES[url] || 'home', t.rand(t.NE_BACK_FWD_MIN_MS, t.NE_BACK_FWD_MAX_MS));
   }
 
   function updateNavButtons() {
@@ -408,7 +414,48 @@ window.APC.netescape = (function () {
       return;
     }
 
-    renderPage(pageKey);
+    // Protected Path latency: typed URL → initial-load delay (300–900ms);
+    // link click / refresh → in-session nav delay (150–500ms).
+    var t = window.APC.timing;
+    var delay = fromUserInput
+      ? t.rand(t.NE_INITIAL_LOAD_MIN_MS, t.NE_INITIAL_LOAD_MAX_MS)
+      : t.rand(t.NE_NAV_MIN_MS, t.NE_NAV_MAX_MS);
+    startPageLoad(normalized, pageKey, delay);
+  }
+
+  // --- Protected Path page load ----------------------------------------
+
+  // Cancel any in-flight page-load delay and reset cursor.
+  function cancelPageLoad() {
+    if (pageLoadTimer)    { clearTimeout(pageLoadTimer);    pageLoadTimer = null;    }
+    if (pageLoadMidTimer) { clearTimeout(pageLoadMidTimer); pageLoadMidTimer = null; }
+    document.body.style.cursor = '';
+  }
+
+  // startPageLoad — runs the Protected Path status bar sequence then renders the page.
+  // delay is capped at 1000ms (Protected Path rule: max 1s, no failures).
+  function startPageLoad(url, pageKey, delay) {
+    cancelPageLoad();
+    var capped = Math.min(delay, 1000);
+
+    // Hourglass cursor for any delay that will exceed 300ms.
+    if (capped > 300) { document.body.style.cursor = 'wait'; }
+
+    // Status sequence: "" → "Opening page [url]..." → "Transferring data from [url]..."
+    // Final "Done" is set by renderPage().
+    if (statusEl) { statusEl.textContent = ''; }
+    if (statusEl) { statusEl.textContent = 'Opening page ' + url + '...'; }
+
+    pageLoadMidTimer = setTimeout(function () {
+      if (statusEl) { statusEl.textContent = 'Transferring data from ' + url + '...'; }
+    }, Math.floor(capped / 2));
+
+    pageLoadTimer = setTimeout(function () {
+      pageLoadTimer = null;
+      pageLoadMidTimer = null;
+      document.body.style.cursor = '';
+      renderPage(pageKey);
+    }, capped);
   }
 
   // --- Page renderer ---------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `startPageLoad(url, pageKey, delay)` helper that drives the status bar sequence: `""` → `"Opening page [url]..."` → `"Transferring data from [url]..."` → `"Done"`
- Typed URL (address bar / Go): 300–900ms delay (`NE_INITIAL_LOAD`); link click / refresh: 150–500ms (`NE_NAV`); Back/Forward: 100–400ms (`NE_BACK_FWD`) — all from `win98-timing.js` tokens
- `cancelPageLoad()` clears any in-flight timers on new navigation; `cursor:wait` applied for delays >300ms per Protected Path rules
- All delays capped at 1000ms (Protected Path max)

## Test plan
- [ ] Open NetEscape → click a nav link → status bar shows `"Opening page..."` then `"Transferring data..."` then `"Done"` within ~500ms
- [ ] Type a URL in address bar + press Enter → same sequence, slightly longer (~300–900ms)
- [ ] Click Back or Forward → status bar sequence visible, 100–400ms delay
- [ ] Click Refresh → 150–500ms re-load sequence (same as link click)
- [ ] No console errors; cursor reverts to default after each load
- [ ] Clicking a second link while first is loading cancels the first (no stale "Done" after navigating away)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)