### PR TITLE
Feature: address bar partial-load freeze for unknown URLs

### DIFF
--- a/css/netescape-base.css
+++ b/css/netescape-base.css
@@ -341,17 +341,147 @@
 }
 
 /* ---------------------------------------------------------------
-   IE stub page — placeholder for pages not yet built
+   Partial-load stub page — shown for unknown / external URLs.
+   Mimics a page that started loading then froze on a 30kbps modem.
+   White background, grey placeholder bars — not NetEscape chrome.
 --------------------------------------------------------------- */
 
 .netescape-stub {
-  padding: 16px;
-  font-family: Verdana, sans-serif;
-  font-size: 11px;
-  color: #C0C0C0;
-  background: #000080;
+  padding: 12px;
+  background: #FFFFFF;
   min-height: 100%;
   box-sizing: border-box;
+}
+
+/* Grey title bar — simulates a partial page heading */
+.netescape-stub__bar {
+  height: 18px;
+  background: #C0C0C0;
+  margin-bottom: 12px;
+}
+
+/* Container for broken image boxes — inline-block row */
+.netescape-stub__imgs {
+  margin-bottom: 12px;
+}
+
+/* Broken image placeholder — grey box with sunken inset border */
+.netescape-stub__img-box {
+  display: inline-block;
+  width: 60px;
+  height: 50px;
+  background: #E0E0E0;
+  border: 1px solid;
+  border-color: #808080 #FFFFFF #FFFFFF #808080;
+  margin-right: 8px;
+  vertical-align: top;
+}
+
+/* Text line placeholders — grey bars of varying width */
+.netescape-stub__line {
+  height: 8px;
+  background: #C0C0C0;
+  margin-bottom: 6px;
+  width: 100%;
+}
+
+.netescape-stub__line--w60 { width: 60%; }
+.netescape-stub__line--w80 { width: 80%; }
+.netescape-stub__line--w45 { width: 45%; }
+
+/* ---------------------------------------------------------------
+   Freeze dialog — Win98-style modal: "Dial-up is too busy."
+   Shown after NE_FREEZE_DELAY_MS when an unknown URL is entered.
+--------------------------------------------------------------- */
+
+.netescape-freeze-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 5000;
+}
+
+.netescape-freeze-dialog__win {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 300px;
+  background: #C0C0C0;
+  border: 2px solid;
+  border-color: #FFFFFF #808080 #808080 #FFFFFF;
+  outline: 1px solid #000000;
+}
+
+.netescape-freeze-dialog__titlebar {
+  height: 18px;
+  padding: 2px;
+  background: linear-gradient(to right, #000080, #1084D0);
+}
+
+.netescape-freeze-dialog__title {
+  display: block;
+  color: #FFFFFF;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 11px;
+  font-weight: bold;
+  line-height: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.netescape-freeze-dialog__body {
+  padding: 16px 14px 8px;
+  overflow: hidden;
+}
+
+/* Warning icon — floated left, body text wraps beside it */
+.netescape-freeze-dialog__icon {
+  float: left;
+  font-size: 28px;
+  line-height: 1;
+  margin-right: 10px;
+  margin-top: 2px;
+}
+
+.netescape-freeze-dialog__msg {
+  overflow: hidden;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #000000;
+  margin: 0;
+}
+
+/* Footer: two buttons right-aligned */
+.netescape-freeze-dialog__footer {
+  padding: 4px 14px 12px;
+  text-align: right;
+}
+
+.netescape-freeze-dialog__btn {
+  background: #C0C0C0;
+  border: 2px solid;
+  border-color: #FFFFFF #808080 #808080 #FFFFFF;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 11px;
+  padding: 3px 0;
+  min-width: 75px;
+  cursor: pointer;
+  margin-left: 6px;
+}
+
+.netescape-freeze-dialog__btn:active {
+  border-color: #808080 #FFFFFF #FFFFFF #808080;
+  padding-top: 4px;
+  padding-left: 1px;
+}
+
+.netescape-freeze-dialog__btn:focus {
+  outline: 1px dotted #000000;
+  outline-offset: -4px;
 }
 
 /* ---------------------------------------------------------------

--- a/js/netescape.js
+++ b/js/netescape.js
@@ -75,6 +75,10 @@ window.APC.netescape = (function () {
   let fwdBtn = null;          // reference to Forward <button>
   let currentParams = {};     // parsed query params for the current page
 
+  // Partial-load freeze timer — fires after NE_FREEZE_DELAY_MS to show the "too busy"
+  // dialog. Cancelled whenever the user navigates to a known URL.
+  let freezeTimer = null;
+
   // --- Public API ------------------------------------------------------
 
   // connect(onComplete) — plays the dial-up sequence and sets isConnected.
@@ -379,8 +383,11 @@ window.APC.netescape = (function () {
     navIndex = navHistory.length - 1;
     updateNavButtons();
 
-    // Resolve to page key; unknown URLs fall back silently to homepage.
-    const pageKey = PAGE_ROUTES[normalized] || 'home';
+    // Cancel any in-flight partial-load freeze (user navigated away before dialog showed).
+    if (freezeTimer) { clearTimeout(freezeTimer); freezeTimer = null; }
+
+    // Resolve to page key; undefined = unknown / external URL.
+    const pageKey = PAGE_ROUTES[normalized];
 
     // Track manual URL bar entries for analytics.
     if (fromUserInput && window.umami) {
@@ -391,9 +398,17 @@ window.APC.netescape = (function () {
     // Once isConnected is true for the session, all navigations go direct.
     if (!window.APC.session.isConnected) {
       renderNoConnection();
-    } else {
-      renderPage(pageKey);
+      return;
     }
+
+    // Unknown / external URL → partial-load freeze flow.
+    // Never navigate to a real external URL or show a real 404.
+    if (!pageKey) {
+      renderPartialLoad(normalized);
+      return;
+    }
+
+    renderPage(pageKey);
   }
 
   // --- Page renderer ---------------------------------------------------
@@ -1216,6 +1231,143 @@ window.APC.netescape = (function () {
     } catch (e) {
       return false;
     }
+  }
+
+  // --- Partial-load freeze flow ----------------------------------------
+
+  // renderPartialLoad — renders a stub "partial page" for unknown/external URLs,
+  // then after NE_FREEZE_DELAY_MS shows the Win98 "too busy" dialog.
+  // Mimics the authentic experience of a 30kbps modem failing to load a page.
+  function renderPartialLoad(url) {
+    if (!pageEl) { return; }
+    if (statusEl) { statusEl.textContent = 'Connecting...'; }
+
+    // Stub: grey title bar + broken image boxes + partial text lines.
+    pageEl.innerHTML = '';
+    const stub = document.createElement('div');
+    stub.className = 'netescape-stub';
+
+    const titleBar = document.createElement('div');
+    titleBar.className = 'netescape-stub__bar';
+    stub.appendChild(titleBar);
+
+    const imgRow = document.createElement('div');
+    imgRow.className = 'netescape-stub__imgs';
+    for (var i = 0; i < 3; i++) {
+      const box = document.createElement('div');
+      box.className = 'netescape-stub__img-box';
+      box.setAttribute('aria-hidden', 'true');
+      imgRow.appendChild(box);
+    }
+    stub.appendChild(imgRow);
+
+    // Partial text lines of varying width — BEM modifiers for each width, no inline styles.
+    var lineClasses = [
+      'netescape-stub__line netescape-stub__line--w60',
+      'netescape-stub__line',
+      'netescape-stub__line netescape-stub__line--w80',
+      'netescape-stub__line netescape-stub__line--w45'
+    ];
+    lineClasses.forEach(function (cls) {
+      const line = document.createElement('div');
+      line.className = cls;
+      stub.appendChild(line);
+    });
+
+    pageEl.appendChild(stub);
+
+    // Freeze: after NE_FREEZE_DELAY_MS, status bar stalls and dialog appears.
+    freezeTimer = setTimeout(function () {
+      freezeTimer = null;
+      if (statusEl) { statusEl.textContent = 'Error'; }
+      showFreezeDialog(url);
+    }, window.APC.timing.NE_FREEZE_DELAY_MS);
+  }
+
+  // showFreezeDialog — Win98-style dialog: "Dial-up is too busy. Go to ahisaka.com?"
+  // OK → navigate to homepage; Cancel → leave stub visible.
+  function showFreezeDialog(url) {
+    const overlay = document.createElement('div');
+    overlay.className = 'netescape-freeze-dialog';
+    overlay.setAttribute('role', 'alertdialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', 'freeze-dialog-msg');
+
+    const win = document.createElement('div');
+    win.className = 'netescape-freeze-dialog__win';
+
+    const titlebar = document.createElement('div');
+    titlebar.className = 'netescape-freeze-dialog__titlebar';
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'netescape-freeze-dialog__title';
+    titleSpan.textContent = 'NetEscape';
+    titlebar.appendChild(titleSpan);
+    win.appendChild(titlebar);
+
+    const body = document.createElement('div');
+    body.className = 'netescape-freeze-dialog__body';
+
+    const icon = document.createElement('span');
+    icon.className = 'netescape-freeze-dialog__icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '⚠';
+
+    const msg = document.createElement('p');
+    msg.className = 'netescape-freeze-dialog__msg';
+    msg.id = 'freeze-dialog-msg';
+    msg.textContent = 'Dial-up is too busy. Go to ahisaka.com?';
+
+    body.appendChild(icon);
+    body.appendChild(msg);
+    win.appendChild(body);
+
+    const footer = document.createElement('div');
+    footer.className = 'netescape-freeze-dialog__footer';
+
+    const okBtn = document.createElement('button');
+    okBtn.className = 'win98-button netescape-freeze-dialog__btn';
+    okBtn.textContent = 'OK';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'win98-button netescape-freeze-dialog__btn';
+    cancelBtn.textContent = 'Cancel';
+
+    footer.appendChild(okBtn);
+    footer.appendChild(cancelBtn);
+    win.appendChild(footer);
+    overlay.appendChild(win);
+    document.body.appendChild(overlay);
+
+    // Focus OK button for keyboard accessibility.
+    okBtn.focus();
+
+    function close() {
+      if (overlay.parentNode) { overlay.parentNode.removeChild(overlay); }
+    }
+
+    // OK: dismiss dialog and navigate to homepage.
+    okBtn.addEventListener('click', function () {
+      close();
+      navigate(DEFAULT_URL, false);
+    });
+
+    // Cancel: dismiss dialog, leave stub page visible.
+    cancelBtn.addEventListener('click', close);
+
+    // Trap focus within the dialog (only two buttons — cycle between them).
+    overlay.addEventListener('keydown', function (e) {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        if (document.activeElement === okBtn) {
+          cancelBtn.focus();
+        } else {
+          okBtn.focus();
+        }
+      }
+      if (e.key === 'Escape') {
+        close();
+      }
+    });
   }
 
   // --- No-connection page ----------------------------------------------

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -87,6 +87,7 @@
     NE_BACK_FWD_MAX_MS:       400,
     NE_MANUAL_URL_MIN_MS:    1000,  // manual URL entry (dial-up simulation delay)
     NE_MANUAL_URL_MAX_MS:    4000,
+    NE_FREEZE_DELAY_MS:      2500,  // unknown URL: stub renders then freezes before dialog
 
     // -------------------------------------------------------------------------
     // Start Menu  —  TEXTURE ZONE


### PR DESCRIPTION
## Summary
- Unknown/external URLs in the address bar now trigger the authentic partial-load freeze flow instead of silently navigating to homepage
- Status bar shows `"Connecting..."` → stub page renders (grey title bar + broken image boxes + partial text placeholder lines)
- After 2500ms (`NE_FREEZE_DELAY_MS`) the page freezes and a Win98 dialog appears: `"Dial-up is too busy. Go to ahisaka.com?"` — OK navigates to homepage; Cancel leaves stub visible
- Navigating to a known URL before the timer fires cancels it cleanly (`freezeTimer` cleared in `navigate()`)
- Freeze dialog: Win98 chrome style, focus trap (Tab cycles between OK/Cancel), Escape key closes

## Test plan
- [ ] Type an unknown URL (e.g. `google.com`) in address bar → status shows `"Connecting..."` → stub page appears (grey bars, image boxes)
- [ ] Wait 2.5s → dialog appears: `"Dial-up is too busy. Go to ahisaka.com?"`
  - [ ] Click OK → navigates to homepage
  - [ ] Click Cancel → dialog dismisses, stub stays visible
- [ ] Press Escape while dialog is open → dialog closes
- [ ] Tab key cycles between OK and Cancel only (no focus leak)
- [ ] Type unknown URL, then immediately type a known URL before 2.5s → timer cancelled, no dialog appears
- [ ] Known URLs (e.g. `ahisaka.com/about`) are unaffected — load normally
- [ ] No console errors

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)