### PR TITLE
Feature: System Tray + Taskbar behavioral fidelity (Texture Zone) #15

### DIFF
--- a/css/win98.css
+++ b/css/win98.css
@@ -831,3 +831,60 @@
 .win98-window--flicker-gap .win98-window__content {
   visibility: hidden;
 }
+
+/* ---------------------------------------------------------------
+   System tray pop-up balloon  —  TEXTURE ZONE
+   Appears above the system tray at random intervals (90–300s).
+   Dismisses automatically after 4–6s or on close button click.
+   Positioned fixed bottom-right, above the taskbar (28px height).
+--------------------------------------------------------------- */
+
+.win98-tray-popup {
+  position: fixed;
+  bottom: 32px;
+  right: 8px;
+  width: 220px;
+  background: #C0C0C0;
+  border: 2px solid;
+  border-color: #FFFFFF #808080 #808080 #FFFFFF;
+  outline: 1px solid #000000;
+  padding: 6px 24px 6px 8px;
+  z-index: 4000;
+  overflow: hidden;
+}
+
+.win98-tray-popup__msg {
+  display: block;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  line-height: 1.4;
+}
+
+.win98-tray-popup__close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 14px;
+  height: 14px;
+  background: #C0C0C0;
+  border: 1px solid;
+  border-color: #FFFFFF #808080 #808080 #FFFFFF;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 9px;
+  line-height: 12px;
+  text-align: center;
+  padding: 0;
+  cursor: pointer;
+}
+
+.win98-tray-popup__close:active {
+  border-color: #808080 #FFFFFF #FFFFFF #808080;
+  padding-top: 1px;
+  padding-left: 1px;
+}
+
+.win98-tray-popup__close:focus {
+  outline: 1px dotted #000000;
+  outline-offset: -2px;
+}

--- a/js/desktop.js
+++ b/js/desktop.js
@@ -13,7 +13,6 @@ window.APC.desktop = (function () {
   const TASKBAR_HEIGHT = 28;
   const WIN_MIN_WIDTH = 200;
   const WIN_MIN_HEIGHT = 80;
-  const CLOCK_INTERVAL_MS = 1000;
   const TITLEBAR_H = 22;    // titlebar height (18) + padding top (2) + padding bottom (2)
   const DBLCLICK_MS = 400;  // manual double-click detection window in ms
 
@@ -57,8 +56,18 @@ window.APC.desktop = (function () {
 
   function startClock() {
     renderClock();
-    setInterval(renderClock, CLOCK_INTERVAL_MS);
+    scheduleClock();
     bindClockEasterEgg();
+  }
+
+  // Self-rescheduling clock tick — fires every CLOCK_INTERVAL_MS (60s) plus a random
+  // 0–CLOCK_OFFSET_MAX_MS (0–2s) drift per tick, matching the Texture Zone clock spec.
+  function scheduleClock() {
+    var t = window.APC.timing;
+    setTimeout(function () {
+      renderClock();
+      scheduleClock();
+    }, t.CLOCK_INTERVAL_MS + t.rand(0, t.CLOCK_OFFSET_MAX_MS));
   }
 
   function renderClock() {

--- a/js/widgets.js
+++ b/js/widgets.js
@@ -40,13 +40,13 @@ window.APC.widgets = (function () {
   // --- Weather widget -------------------------------------------------
 
   var weatherEl = null;
-  var lastWeatherText = '--';
+  var lastWeatherText = '--\u00B0F';  // placeholder shown while first fetch is in-flight
   var cachedLat = null;   // visitor latitude from Geolocation API (null until resolved)
   var cachedLon = null;   // visitor longitude
 
   function initWeather() {
     weatherEl = document.getElementById('taskbar-weather');
-    if (weatherEl) { weatherEl.textContent = '--'; }
+    if (weatherEl) { weatherEl.textContent = '--\u00B0F'; }
 
     // Request geolocation once; cache coords for all subsequent fetches.
     // If denied, timed out, or unavailable, fall back to Pi default (Portland).
@@ -89,7 +89,11 @@ window.APC.widgets = (function () {
         var emoji = condId !== null ? getWeatherEmoji(condId) : '\uD83C\uDF21';
         var city = (data.name && data.name.length) ? data.name : 'Local';
         lastWeatherText = emoji + ' ' + city + ' ' + temp + '\u00B0F';
-        if (weatherEl) { weatherEl.textContent = lastWeatherText; }
+        // Render delay: keep '--°F' visible for WEATHER_LOAD ms before revealing (Texture Zone)
+        var t = window.APC.timing;
+        setTimeout(function () {
+          if (weatherEl) { weatherEl.textContent = lastWeatherText; }
+        }, t.rand(t.WEATHER_LOAD_MIN_MS, t.WEATHER_LOAD_MAX_MS));
       })
       .catch(function () {
         // Silent fail — display keeps last known value (initialized to '--')
@@ -99,6 +103,10 @@ window.APC.widgets = (function () {
         setTimeout(fetchWeather, WEATHER_INTERVAL_MS);
       });
   }
+
+  // --- Tray pop-up state ----------------------------------------------
+
+  var trayPopupTimer = null;
 
   // --- RAM widget -----------------------------------------------------
 
@@ -127,7 +135,11 @@ window.APC.widgets = (function () {
         if (!data || !data.total || data.total === 0) { throw new Error('Invalid RAM data'); }
         var pct = Math.round((data.used / data.total) * 100);
         lastRamText = 'RAM: ' + pct + '%';
-        if (ramEl) { ramEl.textContent = lastRamText; }
+        // Render delay: wait RAM_RENDER ms before updating display (Texture Zone)
+        var t = window.APC.timing;
+        setTimeout(function () {
+          if (ramEl) { ramEl.textContent = lastRamText; }
+        }, t.rand(t.RAM_RENDER_MIN_MS, t.RAM_RENDER_MAX_MS));
         // Schedule next fetch from success path — explicit, not chained after .catch()
         setTimeout(fetchRam, RAM_INTERVAL_MS);
       })
@@ -161,6 +173,61 @@ window.APC.widgets = (function () {
           window.umami.track('easteregg_trigger', { easter_egg: 'ram_overload' });
         }
       }
+    });
+  }
+
+  // --- Tray pop-ups  (Texture Zone) -----------------------------------
+  // Simulates Win98 security/system notifications from the notification area.
+  // Fires every TRAY_POPUP_MIN–MAX ms; each balloon stays for TRAY_POPUP_DISPLAY ms.
+  // Close button has TRAY_CLICK ms response delay per the timing spec.
+
+  function initTrayPopups() {
+    scheduleTrayPopup();
+  }
+
+  function scheduleTrayPopup() {
+    var t = window.APC.timing;
+    trayPopupTimer = setTimeout(function () {
+      var messages = [
+        'Your computer may be at risk.',
+        'Low disk space on C:'
+      ];
+      showTrayPopup(messages[Math.floor(Math.random() * messages.length)]);
+      scheduleTrayPopup();
+    }, t.rand(t.TRAY_POPUP_MIN_MS, t.TRAY_POPUP_MAX_MS));
+  }
+
+  function showTrayPopup(message) {
+    var t = window.APC.timing;
+
+    var popup = document.createElement('div');
+    popup.className = 'win98-tray-popup';
+    popup.setAttribute('role', 'alert');
+    popup.setAttribute('aria-live', 'assertive');
+
+    var msgEl = document.createElement('span');
+    msgEl.className = 'win98-tray-popup__msg';
+    msgEl.textContent = message;
+
+    var closeBtn = document.createElement('button');
+    closeBtn.className = 'win98-tray-popup__close';
+    closeBtn.textContent = '\u00D7';
+    closeBtn.setAttribute('aria-label', 'Dismiss notification');
+
+    popup.appendChild(msgEl);
+    popup.appendChild(closeBtn);
+    document.body.appendChild(popup);
+
+    var autoTimer = setTimeout(dismiss, t.rand(t.TRAY_POPUP_DISPLAY_MIN_MS, t.TRAY_POPUP_DISPLAY_MAX_MS));
+
+    function dismiss() {
+      clearTimeout(autoTimer);
+      if (popup.parentNode) { popup.parentNode.removeChild(popup); }
+    }
+
+    // TRAY_CLICK_MIN/MAX delay on close button response (Texture Zone tray click latency)
+    closeBtn.addEventListener('click', function () {
+      setTimeout(dismiss, t.rand(t.TRAY_CLICK_MIN_MS, t.TRAY_CLICK_MAX_MS));
     });
   }
 
@@ -226,6 +293,7 @@ window.APC.widgets = (function () {
   function init() {
     initWeather();
     initRam();
+    initTrayPopups();
   }
 
   return { init: init };


### PR DESCRIPTION
## Summary

- **Clock drift**: replaces `setInterval(1s)` with a self-rescheduling `setTimeout` chain — clock updates every 60s + random 0–2s offset (`CLOCK_INTERVAL_MS` + `CLOCK_OFFSET_MAX_MS` tokens), matching authentic Win98 taskbar behavior
- **Weather render delay**: data arrives silently; widget stays at `--°F` for 1500–3000ms (`WEATHER_LOAD_MIN/MAX_MS`) before revealing the real value — simulates slow CPU/render on IBM Aptiva SE7
- **RAM render delay**: 200–400ms display lag after each `/ram` fetch completes (`RAM_RENDER_MIN/MAX_MS`), keeping the last value visible until the delay fires
- **Tray pop-up balloons**: random-interval notifications every 90–300s (`TRAY_POPUP_MIN/MAX_MS`); two alternating messages: *"Your computer may be at risk."* and *"Low disk space on C:"*; each balloon auto-dismisses after 4–6s (`TRAY_POPUP_DISPLAY_MIN/MAX_MS`); close button has 100–200ms response delay (`TRAY_CLICK_MIN/MAX_MS`)
- **CSS**: new `.win98-tray-popup` balloon styles — fixed bottom-right above taskbar, Win98 raised border, 11px MS Sans Serif, miniature 14×14px × close button

All timing values sourced exclusively from `window.APC.timing` tokens in `win98-timing.js`. No new hardcoded delay values.

## Files changed

- `js/desktop.js` — clock drift (remove hardcoded `CLOCK_INTERVAL_MS = 1000`, add `scheduleClock()`)
- `js/widgets.js` — weather/RAM render delays, tray popup system (`initTrayPopups`, `scheduleTrayPopup`, `showTrayPopup`)
- `css/win98.css` — `.win98-tray-popup` and `__msg` / `__close` styles

## Test plan

- [ ] Desktop loads; taskbar clock shows correct time immediately (from `renderClock()` on init)
- [ ] Clock does **not** tick every second — stays frozen until ~60s elapses, then jumps to current time
- [ ] Weather widget shows `--°F` on first load, then reveals real value after 1.5–3s
- [ ] RAM widget shows `--` initially, updates with delay after first fetch
- [ ] Wait 90–300s — a tray balloon appears bottom-right with one of the two messages
- [ ] Balloon auto-dismisses after 4–6s
- [ ] Clicking × on balloon dismisses it with a ~100–200ms lag (not instant)
- [ ] No console errors in Chrome or Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)