### PR TITLE
Fix: weather proxy — add systemd service unit and Caddyfile route

### DIFF
--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -19,4 +19,8 @@
     handle /ram {
         reverse_proxy 127.0.0.1:8091
     }
+
+    handle /weather {
+        reverse_proxy 127.0.0.1:8092
+    }
 }

--- a/config/weather-server.service
+++ b/config/weather-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Weather Proxy Server
+After=network.target
+
+[Service]
+User=atsushi
+ExecStart=/usr/bin/python3 /home/atsushi/weather-server.py
+Restart=always
+RestartSec=5
+EnvironmentFile=/home/atsushi/.env
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Root cause

Two things were missing that together broke the weather widget (#30):

1. **`config/weather-server.service` did not exist** — `weather-server.py` was committed to `config/` but never had a systemd unit. The script was therefore never running on the Pi, so nothing was listening on port 8092.

2. **`config/Caddyfile` had no `/weather` route** — even if the server were running, Caddy had no rule to proxy `/weather` requests to it. The `/ram` and `/altcha` routes were present; `/weather` was absent.

The widget's `fetch('/weather')` calls were silently failing, the `.catch()` kept the last value (`--°F`), and retries scheduled every 10 minutes never succeeded.

## Changes

| File | Change |
|------|--------|
| `config/weather-server.service` | **New** — systemd unit mirroring `ram-server.service`; adds `EnvironmentFile=/home/atsushi/.env` so `OPENWEATHERMAP_API_KEY` reaches the process |
| `config/Caddyfile` | Added `handle /weather { reverse_proxy 127.0.0.1:8092 }` alongside existing `/ram` and `/altcha` routes |

## Deploy steps (manual — config/ files are reference copies)

```bash
# 1. Deploy the systemd unit
scp config/weather-server.service atsushispc:~/weather-server.service
ssh atsushispc sudo cp ~/weather-server.service /etc/systemd/system/weather-server.service
ssh atsushispc sudo systemctl daemon-reload
ssh atsushispc sudo systemctl enable --now weather-server

# 2. Verify it's running and the endpoint responds
ssh atsushispc sudo systemctl status weather-server
ssh atsushispc curl -s http://127.0.0.1:8092/weather | python3 -m json.tool

# 3. Update Caddyfile
ssh atsushispc sudo cp /etc/caddy/Caddyfile /etc/caddy/Caddyfile.bak
scp config/Caddyfile atsushispc:/tmp/Caddyfile
ssh atsushispc sudo cp /tmp/Caddyfile /etc/caddy/Caddyfile
ssh atsushispc sudo systemctl reload caddy

# 4. End-to-end check
curl https://ahisaka.com/weather
```

## Test plan

- [ ] `sudo systemctl status weather-server` → active (running)
- [ ] `curl http://127.0.0.1:8092/weather` → valid JSON with `main.temp`, `weather[0].id`, `name`
- [ ] `curl http://127.0.0.1:8092/weather?lat=37.7749&lon=-122.4194` → San Francisco weather
- [ ] `curl https://ahisaka.com/weather` → same JSON through Caddy
- [ ] Weather widget on the live site updates within 3s of page load
- [ ] After `sudo reboot`, `weather-server` comes back up automatically

Closes #30, closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)