### PR TITLE
Feature: Altcha server-side HMAC verification via Pocketbase hook (#8)

### DIFF
--- a/config/pocketbase.service
+++ b/config/pocketbase.service
@@ -8,6 +8,7 @@ WorkingDirectory=/home/atsushi/pocketbase
 ExecStart=/home/atsushi/pocketbase/pocketbase serve --http=127.0.0.1:8090
 Restart=always
 RestartSec=5
+EnvironmentFile=/home/atsushi/.env
 
 [Install]
 WantedBy=multi-user.target

--- a/pb_hooks/guestbook_verify.pb.js
+++ b/pb_hooks/guestbook_verify.pb.js
@@ -1,0 +1,110 @@
+// pb_hooks/guestbook_verify.pb.js
+// Server-side Altcha proof-of-work verification for guestbook submissions.
+// Runs on every guestbook beforeCreate event; rejects any POST that does not
+// carry a valid, HMAC-signed Altcha payload.
+//
+// Verified against PocketBase 0.28.2 API:
+//   $app.onRecordBeforeCreateRequest(handler, 'collection')
+//   $security.sha256(text)         → hex SHA-256 string
+//   $security.hs256(text, key)     → hex HMAC-SHA256 string
+//   $os.getenv(key)                → environment variable string
+//   throw new BadRequestError(msg) → 400 response
+//   e.next()                       → proceed with record creation
+//
+// atob() and Buffer are NOT available in PocketBase's goja runtime.
+// base64Decode() below is a pure-JS implementation.
+//
+// Challenge protocol (mirrors altcha-server.py exactly):
+//   challenge  = SHA-256(salt + number)         ← client brute-forces number
+//   signature  = HMAC-SHA256(secret, challenge) ← proves challenge came from our server
+//
+// Required: 'altcha' text field in guestbook collection (stores the encoded payload).
+// Required: ALTCHA_HMAC_SECRET env var — loaded via EnvironmentFile in pocketbase.service.
+//
+// Deploy:
+//   cp pb_hooks/guestbook_verify.pb.js /home/atsushi/pocketbase/pb_hooks/
+//   sudo systemctl restart pocketbase
+
+// ---------------------------------------------------------------------------
+// Pure-JS base64 decoder — atob() is not available in PocketBase's JS runtime
+// ---------------------------------------------------------------------------
+
+function base64Decode(str) {
+  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+  var out = '';
+  // Strip any characters that are not valid base64
+  str = str.replace(/[^A-Za-z0-9+/=]/g, '');
+  var i = 0;
+  while (i < str.length) {
+    var e1 = chars.indexOf(str.charAt(i++));
+    var e2 = chars.indexOf(str.charAt(i++));
+    var e3 = chars.indexOf(str.charAt(i++));
+    var e4 = chars.indexOf(str.charAt(i++));
+    var c1 = (e1 << 2) | (e2 >> 4);
+    var c2 = ((e2 & 15) << 4) | (e3 >> 2);
+    var c3 = ((e3 & 3) << 6) | e4;
+    out += String.fromCharCode(c1);
+    if (e3 !== 64) { out += String.fromCharCode(c2); }
+    if (e4 !== 64) { out += String.fromCharCode(c3); }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Guestbook beforeCreate hook
+// ---------------------------------------------------------------------------
+
+$app.onRecordBeforeCreateRequest(function (e) {
+  // 1. Read the submitted Altcha payload
+  var payload = e.record.get('altcha');
+  if (!payload) {
+    throw new BadRequestError('Missing Altcha payload');
+  }
+
+  // 2. Decode base64 → JSON
+  var decoded;
+  try {
+    decoded = JSON.parse(base64Decode(String(payload)));
+  } catch (_) {
+    throw new BadRequestError('Invalid Altcha payload');
+  }
+
+  var algorithm = decoded.algorithm;
+  var challenge = decoded.challenge;
+  var number    = decoded.number;
+  var salt      = decoded.salt;
+  var signature = decoded.signature;
+
+  // 3. Ensure all required fields are present
+  if (!algorithm || !challenge || number === undefined || !salt || !signature) {
+    throw new BadRequestError('Incomplete Altcha payload');
+  }
+
+  // 4. Only SHA-256 is supported (matches altcha-server.py)
+  if (algorithm !== 'SHA-256') {
+    throw new BadRequestError('Unsupported Altcha algorithm: ' + algorithm);
+  }
+
+  // 5. Re-derive and verify the challenge: SHA-256(salt + number)
+  var expectedChallenge = $security.sha256(salt + String(number));
+  if (expectedChallenge !== challenge) {
+    throw new BadRequestError('Altcha challenge mismatch');
+  }
+
+  // 6. Re-derive and verify the HMAC signature: HMAC-SHA256(secret, challenge)
+  //    $security.hs256(text, key) — text is the message, key is the HMAC secret
+  var secret = $os.getenv('ALTCHA_HMAC_SECRET');
+  if (!secret) {
+    // Secret not configured — fail closed rather than silently accepting submissions
+    throw new Error('ALTCHA_HMAC_SECRET is not set in the environment');
+  }
+
+  var expectedSignature = $security.hs256(challenge, secret);
+  if (expectedSignature !== signature) {
+    throw new BadRequestError('Altcha signature invalid');
+  }
+
+  // All checks passed — proceed with record creation
+  e.next();
+
+}, 'guestbook');


### PR DESCRIPTION
## Summary

- **`pb_hooks/guestbook_verify.pb.js`** — new `onRecordBeforeCreateRequest` hook for the `guestbook` collection. Verifies the Altcha proof-of-work payload before any record is accepted.
- **`config/pocketbase.service`** — adds `EnvironmentFile=/home/atsushi/.env` so `ALTCHA_HMAC_SECRET` is available to Pocketbase and its hooks. Without this, `$os.getenv('ALTCHA_HMAC_SECRET')` silently returns empty string.

## How the verification works

Mirrors `altcha-server.py` exactly — same protocol, opposite direction:

| Step | What the server checks |
|------|----------------------|
| 1 | `altcha` field present in submission |
| 2 | Base64 decode → valid JSON with `algorithm`, `challenge`, `number`, `salt`, `signature` |
| 3 | `algorithm === 'SHA-256'` |
| 4 | `SHA-256(salt + number) === challenge` — client actually solved the PoW |
| 5 | `HMAC-SHA256(secret, challenge) === signature` — challenge came from our server |

Any failure → `BadRequestError` (400). Fails **closed** if `ALTCHA_HMAC_SECRET` is unset.

## Key API decisions (PocketBase 0.28.2)

| Concern | Solution |
|---------|----------|
| Hook registration | `$app.onRecordBeforeCreateRequest(fn, 'guestbook')` + `e.next()` |
| SHA-256 | `$security.sha256(text)` |
| HMAC-SHA256 | `$security.hs256(text, key)` — NOT `.hmac()` (issue skeleton was wrong) |
| Base64 decode | Pure-JS `base64Decode()` — `atob()` is not available in PocketBase's goja runtime |
| Env vars | `$os.getenv('ALTCHA_HMAC_SECRET')` — requires `EnvironmentFile` in service |

## Prerequisites

**The `guestbook` collection must have an `altcha` text field.** If it doesn't exist, all submissions will fail with "Missing Altcha payload". Add it via the Pocketbase admin UI at `http://localhost:8090/_/` (SSH tunnel). Set it as optional in the schema — the hook enforces its presence at the application layer.

## Deploy steps

```bash
# 1. Deploy the hook
ssh atsushispc cp /home/atsushi/site/pb_hooks/guestbook_verify.pb.js /home/atsushi/pocketbase/pb_hooks/guestbook_verify.pb.js

# 2. Update the Pocketbase service (adds EnvironmentFile)
ssh atsushispc sudo cp /home/atsushi/site/config/pocketbase.service /etc/systemd/system/pocketbase.service
ssh atsushispc sudo systemctl daemon-reload

# 3. Restart Pocketbase to load the new service config and hook
ssh atsushispc sudo systemctl restart pocketbase
ssh atsushispc sudo systemctl status pocketbase
```

## Test plan

- [ ] Confirm `altcha` field exists in guestbook collection (add via admin UI if not)
- [ ] Submit guestbook form normally → 201 Created, entry appears in Pocketbase
- [ ] POST to `/api/collections/guestbook/records` without `altcha` field → 400
- [ ] POST with `altcha: "invalidbase64!!"` → 400
- [ ] POST with valid base64 but wrong HMAC → 400
- [ ] POST with valid base64, correct challenge derivation, wrong signature → 400
- [ ] `sudo systemctl status pocketbase` → active (running) after deploy
- [ ] Pocketbase logs show no hook errors: `sudo journalctl -u pocketbase -f`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)