### PR TITLE
Feature: Win98 Start Menu with cascading submenus + Shut Down modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,11 @@ atsushis-pc/
 ├── projects.html               ← NetEscape Work/Projects
 ├── guestbook.html              ← NetEscape Guestbook
 ├── js/
+│   ├── win98-timing.js             ← All timing tokens live here; never hardcode delays elsewhere
 │   ├── boot.js
 │   ├── desktop.js
-│   ├── ie.js
+│   ├── taskbar.js                  ← Start Menu (Programs, Documents, Shut Down modal)
+│   ├── netescape.js                ← NetEscape browser window (renamed from ie.js)
 │   ├── widgets.js
 │   └── apps/
 │       ├── winamp.js
@@ -166,7 +168,7 @@ atsushis-pc/
 * Core shells:
   * `js/desktop.js`: Desktop/window management
   * `js/boot.js`: Handles Matrix → terminal prompt → loading bar → desktop fade-in
-  * `js/ie.js`: NetEscape browser window (routing, dial-up logic, navigation) — **pending rename to `netescape.js` as part of brand pivot**
+  * `js/netescape.js`: NetEscape browser window (routing, dial-up logic, navigation)
   * `js/widgets.js`: Taskbar widgets (weather, RAM, clock)
   * `js/win98-timing.js`: Centralised timing token file — all delay values live here, never hardcoded elsewhere
 
@@ -298,7 +300,7 @@ Modem reality: V.90 was limited by telephone infrastructure optimised for voice.
 | Microsoft | Microblob |
 | Internet Explorer | NetEscape |
 
-CSS files and JS modules currently named `ie-*.css` / `ie.js` are pending rename to `netescape-*.css` / `netescape.js` as part of the brand pivot. Do not create new files using the `ie-` prefix.
+`js/netescape.js` and `css/netescape-*.css` are the canonical names. Do not create new files using the `ie-` prefix. Existing `ie-*.css` files are pending rename to `netescape-*.css` (tracked separately — do not rename as part of unrelated PRs).
 
 ### Matrix Gate Screen — Load Immediately
 
@@ -350,10 +352,25 @@ Status bar sequence: `""` → `"Opening page [url]..."` → `"Transferring data 
 | Action | Delay |
 | --- | --- |
 | Open | 80–180ms |
-| Submenu expand | 200–400ms |
+| Submenu expand (mouse hover) | 200–400ms |
+| Submenu expand (keyboard Right) | Immediate — no delay |
+| Submenu close (after mouse leaves) | 300ms — cancelled on mouse re-entry |
 | Item → action | 100–250ms |
 
 Failure: 1-in-12 chance menu flickers closed on open (requires second click).
+
+**Menu items:** Programs ► | Documents ► | Settings (disabled) | Find (disabled) | Help | Run… | — | Shut Down…
+
+**Programs submenu:** Winamp, Minesweeper, Calculator, Notepad — dispatches to `desktop.launchApp()`.
+
+**Documents submenu:** Populated just-in-time from `sessionStorage['ne_history']` (up to 10 recent NetEscape URLs). `netescape.js` writes to this key at the end of `renderPage()`.
+
+**Shut Down modal — three radio options:**
+1. **Shut Down** — shows a non-dismissable black "It is now safe to turn off your computer." overlay.
+2. **Restart the computer** — fires Umami `shutdown_trigger`, 100ms tick, then `sessionStorage.clear()` + `boot.restart()` (soft restart, no page reload).
+3. **Close all programs and log off as Atsushi** — closes all open windows via `desktop.closeAll()`, then shows: `"Thanks for visiting. Close the tab whenever you're ready."` ← **intentional deviation from the original "Restart in MS-DOS mode" spec slot.** Log Off was chosen because it provides a genuine recruiter-facing goodbye moment. Do not revert to MS-DOS mode.
+
+**`beforeunload` Umami event:** Registered as best-effort via `navigator.sendBeacon()`. Umami CDN does not expose a sendBeacon API, so this is currently a documented no-op. **QA note: mark as "expected to be unreliable / not tracked" — do not treat missing beforeunload events as a bug.**
 
 #### Desktop App Launches (Texture Zone)
 
@@ -503,7 +520,7 @@ Before each milestone:
 
   **Correct**: All chrome corners are sharp. Set `border-radius: 0` if needed.
 * **Pitfall**: Dial-up runs on every NetEscape navigation
-  **Correct**: Dial-up *only* on (1) first NetEscape session and (2) manual URL entry. Track `hasDialedUp` boolean in `ie.js` (pending rename to `netescape.js`).
+  **Correct**: Dial-up *only* on (1) first NetEscape session and (2) manual URL entry. Track `hasDialedUp` boolean in `netescape.js`.
 * **Pitfall**: Rendering guestbook entries with unsanitized HTML  
 
   **Correct**: Always set text with `textContent`; validate URLs before rendering `<a>`.

--- a/css/win98.css
+++ b/css/win98.css
@@ -218,32 +218,240 @@
 }
 
 /* ---------------------------------------------------------------
-   Start menu stub
+   Start menu — full Win98 implementation
+   z-index 5000: above taskbar (999), context menu (2000),
+   msgbox overlay (2999), tray popup (4000).
 --------------------------------------------------------------- */
 
 #start-menu {
   position: absolute;
   bottom: 28px;
   left: 0;
-  width: 200px;
+  /* Banner (22px) + items area: total ~240px */
+  width: 240px;
   background: #C0C0C0;
   border: 2px solid;
   border-color: #FFFFFF #808080 #808080 #FFFFFF;
   outline: 1px solid #000000;
-  z-index: 1000;
+  z-index: 5000;
   display: none;
+  /* overflow: visible so submenus can extend outside menu bounds */
+  overflow: visible;
 }
 
 #start-menu.start-menu--open {
   display: block;
 }
 
-.start-menu__stub {
+/* Left gradient banner — "WinDoors 98" vertical text */
+.start-menu__banner {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 22px;
+  background: linear-gradient(to top, #000080, #1084D0);
+  overflow: hidden;
+}
+
+.start-menu__banner-text {
+  display: block;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 16px;
+  font-weight: bold;
+  color: #FFFFFF;
+  /* Vertical text: writing-mode + rotate for bottom-up reading order */
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  white-space: nowrap;
+  letter-spacing: 2px;
+  position: absolute;
+  bottom: 6px;
+  left: 2px;
+}
+
+/* Items container — occupies space to the right of the banner */
+.start-menu__items {
+  margin-left: 22px;
+  padding: 2px 0;
+}
+
+/* Individual menu item */
+.start-menu__item {
+  position: relative;  /* anchor for .start-menu__submenu absolute positioning */
+  display: block;
+  padding: 4px 20px 4px 4px;
   font-family: 'MS Sans Serif', Tahoma, sans-serif;
   font-size: 11px;
+  color: #000000;
+  cursor: default;
+  white-space: nowrap;
+  overflow: visible;
+  /* Sharp corners — no border-radius */
+}
+
+.start-menu__item:hover,
+.start-menu__item:focus,
+.start-menu__item--open {
+  background: #000080;
+  color: #FFFFFF;
+  outline: none;
+}
+
+.start-menu__item--disabled {
   color: #808080;
-  padding: 12px;
-  margin: 0;
+}
+
+.start-menu__item--disabled:hover,
+.start-menu__item--disabled:focus {
+  background: none;
+  color: #808080;
+  cursor: default;
+}
+
+.start-menu__item-icon {
+  display: inline-block;
+  width: 20px;
+  font-size: 13px;
+  text-align: center;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+.start-menu__item-label {
+  vertical-align: middle;
+}
+
+/* Submenu arrow — absolute right edge of item */
+.start-menu__item-arrow {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  margin-top: -5px;
+  font-size: 9px;
+  line-height: 1;
+}
+
+/* Win98 double-line separator */
+.start-menu__separator {
+  height: 0;
+  border: none;
+  border-top: 1px solid #808080;
+  border-bottom: 1px solid #FFFFFF;
+  margin: 2px 4px;
+}
+
+/* Cascading submenu — pops out to the right of the parent item */
+.start-menu__submenu {
+  display: none;
+  position: absolute;
+  left: 100%;
+  top: 0;
+  background: #C0C0C0;
+  border: 2px solid;
+  border-color: #FFFFFF #808080 #808080 #FFFFFF;
+  outline: 1px solid #000000;
+  min-width: 160px;
+  /* Above the main menu */
+  z-index: 5001;
+  padding: 2px 0;
+}
+
+.start-menu__submenu--open {
+  display: block;
+}
+
+/* Submenu item — same style as top-level items */
+.start-menu__submenu-item {
+  display: block;
+  padding: 4px 20px 4px 4px;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  cursor: default;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 240px;
+}
+
+.start-menu__submenu-item:hover,
+.start-menu__submenu-item:focus {
+  background: #000080;
+  color: #FFFFFF;
+  outline: none;
+}
+
+.start-menu__submenu-item--empty {
+  color: #808080;
+}
+
+.start-menu__submenu-item--empty:hover,
+.start-menu__submenu-item--empty:focus {
+  background: none;
+  color: #808080;
+  cursor: default;
+}
+
+/* ---------------------------------------------------------------
+   Shut Down dialog — extends win98-msgbox styles
+--------------------------------------------------------------- */
+
+.win98-msgbox--shutdown {
+  width: 320px;
+  margin-left: -160px;
+}
+
+.shutdown-prompt {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 12px;
+}
+
+.shutdown-prompt__icon {
+  width: 40px;
+  vertical-align: top;
+  font-size: 28px;
+  line-height: 1;
+  padding-right: 8px;
+}
+
+.shutdown-prompt__text {
+  vertical-align: middle;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 11px;
+  color: #000000;
+}
+
+.shutdown-radios {
+  margin: 8px 0 16px 12px;
+}
+
+.shutdown-radio-row {
+  margin-bottom: 6px;
+}
+
+.shutdown-radio {
+  vertical-align: middle;
+  margin-right: 6px;
+}
+
+.shutdown-radio-label {
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 11px;
+  color: #000000;
+  vertical-align: middle;
+  cursor: default;
+}
+
+/* Button row for dialogs with multiple buttons */
+.win98-msgbox__btnrow {
+  text-align: center;
+  padding: 4px 0 0;
+}
+
+.win98-msgbox__btnrow .win98-msgbox__ok {
+  margin: 0 4px;
 }
 
 /* ---------------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -75,10 +75,8 @@
     <!-- Window layer — windows are appended here by desktop.js -->
     <div id="window-layer"></div>
 
-    <!-- Start menu stub — toggled by start button -->
-    <div id="start-menu" aria-label="Start menu" role="menu">
-      <p class="start-menu__stub">Start menu coming soon</p>
-    </div>
+    <!-- Start menu — content built by taskbar.js on init() -->
+    <div id="start-menu" role="menu" aria-label="Start menu"></div>
 
     <!-- Taskbar: start button (float left), system tray (float right),
          taskbar-windows fills remaining width via BFC (overflow:hidden) -->
@@ -102,6 +100,7 @@
 
   <script src="js/win98-timing.js"></script>
   <script src="js/desktop.js"></script>
+  <script src="js/taskbar.js"></script>
   <script src="js/netescape.js"></script>
   <script src="js/apps/winamp.js"></script>
   <script src="js/apps/calculator.js"></script>

--- a/js/boot.js
+++ b/js/boot.js
@@ -546,6 +546,99 @@ window.APC.boot = (function () {
     }, skipDelay ? 0 : window.APC.timing.BOOT_DESKTOP_PAUSE_MS);
   }
 
-  return { init };
+  // --- Soft restart ---------------------------------------------------
+  // Resets all module state and re-runs the full gate → boot → desktop
+  // sequence without a page reload. Called by the Start Menu Shut Down
+  // dialog when the user selects "Restart the computer".
+
+  function restart() {
+    // Reset module-level animation state.
+    hasStarted = false;
+    identityPhase = 'waiting';
+    identityTyped1 = '';
+    identityTyped2 = '';
+    if (animFrame) { cancelAnimationFrame(animFrame); animFrame = null; }
+    startupAudio = null;
+
+    // Reset session connection state.
+    if (window.APC.session) { window.APC.session.isConnected = false; }
+
+    // Reset netescape and desktop module state (avoids dangling references).
+    if (window.APC.netescape && typeof window.APC.netescape.reset === 'function') {
+      window.APC.netescape.reset();
+    }
+    if (window.APC.desktop && typeof window.APC.desktop.reset === 'function') {
+      window.APC.desktop.reset();
+    }
+
+    // Clear session keys so init() runs the full sequence.
+    sessionStorage.removeItem('boot_complete');
+    sessionStorage.removeItem('ne_history');
+
+    // Reset DOM — hide desktop, clear open windows and taskbar buttons.
+    var desktop = document.getElementById('desktop');
+    if (desktop) { desktop.classList.add('desktop--hidden'); }
+
+    var windowLayer = document.getElementById('window-layer');
+    if (windowLayer) { windowLayer.innerHTML = ''; }
+
+    var taskbarWindows = document.getElementById('taskbar-windows');
+    if (taskbarWindows) { taskbarWindows.innerHTML = ''; }
+
+    // Reset boot progress track.
+    var track = document.getElementById('boot-progress-track');
+    if (track) { track.innerHTML = ''; track.setAttribute('aria-valuenow', '0'); }
+
+    var bootScreen = document.getElementById('boot-screen');
+    if (bootScreen) {
+      bootScreen.classList.add('boot-screen--hidden');
+      bootScreen.classList.remove('boot-screen--fade');
+    }
+
+    // Show gate screen fresh.
+    var gate = document.getElementById('gate-screen');
+    if (gate) {
+      gate.classList.remove('gate-screen--hidden');
+      gate.classList.remove('gate-screen--fade');
+    }
+
+    var gatePrompt = document.getElementById('gate-prompt');
+    if (gatePrompt) { gatePrompt.classList.add('gate-prompt--hidden'); }
+
+    // Re-run the boot init — sets up canvas, rain, and gate listeners.
+    init();
+  }
+
+  // --- Shutdown screen -------------------------------------------------
+  // Shows a non-dismissable "safe to turn off" overlay — the simulation
+  // equivalent of WinDoors 98 powering off.
+
+  function shutdown() {
+    if (window.umami) { window.umami.track('shutdown_trigger'); }
+
+    var overlay = document.createElement('div');
+    overlay.setAttribute('role', 'alertdialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', 'Shut down');
+    overlay.style.cssText = [
+      'position:fixed;top:0;left:0;width:100%;height:100%;',
+      'background:#000000;',
+      'z-index:99999;',
+      'font-family:"MS Sans Serif",Tahoma,sans-serif;'
+    ].join('');
+
+    var msg = document.createElement('div');
+    msg.style.cssText = [
+      'position:absolute;bottom:80px;left:0;right:0;',
+      'color:#FFFFFF;font-size:13px;text-align:center;',
+      'line-height:1.8;'
+    ].join('');
+    msg.textContent = 'It is now safe to turn off your computer.';
+
+    overlay.appendChild(msg);
+    document.body.appendChild(overlay);
+  }
+
+  return { init: init, restart: restart, shutdown: shutdown };
 
 }());

--- a/js/desktop.js
+++ b/js/desktop.js
@@ -44,8 +44,11 @@ window.APC.desktop = (function () {
   function init() {
     startClock();
     bindDesktopIcons();
-    bindStartButton();
     bindContextMenu();
+    // Start menu is owned by taskbar.js which is loaded before desktop.js fires.
+    if (window.APC.taskbar && typeof window.APC.taskbar.init === 'function') {
+      window.APC.taskbar.init();
+    }
     // Widgets fire their first fetch immediately; subsequent fetches self-schedule via setTimeout.
     if (window.APC.widgets && typeof window.APC.widgets.init === 'function') {
       window.APC.widgets.init();
@@ -1179,8 +1182,40 @@ window.APC.desktop = (function () {
     contentEl.appendChild(wrap);
   }
 
+  // --- Close all windows -----------------------------------------------
+  // Called by Start Menu Log Off action and by boot.restart().
+
+  function closeAll() {
+    var ids = Object.keys(windows);
+    ids.forEach(function (id) {
+      if (windows[id]) { closeWindow(windows[id]); }
+    });
+    syspropsState = null;
+  }
+
+  // --- Module reset (called by boot.restart()) -------------------------
+  // Discards all window references so state is clean when desktop.init()
+  // fires again after the gate/boot sequence replays. DOM cleanup (removing
+  // window-layer and taskbar-windows children) is done by boot.restart().
+
+  function reset() {
+    Object.keys(windows).forEach(function (id) { delete windows[id]; });
+    Object.keys(iconLastClick).forEach(function (k) { delete iconLastClick[k]; });
+    Object.keys(appLaunching).forEach(function (k) { delete appLaunching[k]; });
+    zCounter = 100;
+    winIdCounter = 0;
+    activeWindowId = null;
+    syspropsState = null;
+  }
+
   // --- Public exports --------------------------------------------------
 
-  return { init: init, createWindow: createWindow };
+  return {
+    init:         init,
+    createWindow: createWindow,
+    launchApp:    launchApp,
+    closeAll:     closeAll,
+    reset:        reset
+  };
 
 }());

--- a/js/netescape.js
+++ b/js/netescape.js
@@ -473,6 +473,22 @@ window.APC.netescape = (function () {
       guestbook: renderGuestbook
     };
     (renderers[pageKey] || renderHome)();
+
+    // Record nav history AFTER successful render so Start Menu > Documents
+    // always reflects pages that actually loaded (not just navigation attempts).
+    recordNavHistory(currentUrl);
+  }
+
+  // Persist up to 10 recently visited URLs in sessionStorage for Start Menu > Documents.
+  // Deduplicates: re-visiting a URL moves it to the front. Called at end of renderPage().
+  function recordNavHistory(url) {
+    try {
+      var hist = JSON.parse(sessionStorage.getItem('ne_history') || '[]');
+      hist = hist.filter(function (u) { return u !== url; });
+      hist.unshift(url);
+      if (hist.length > 10) { hist = hist.slice(0, 10); }
+      sessionStorage.setItem('ne_history', JSON.stringify(hist));
+    } catch (e) {}
   }
 
   function renderHome() {
@@ -1584,8 +1600,29 @@ window.APC.netescape = (function () {
     });
   }
 
+  // --- Module reset (called by boot.restart()) -------------------------
+  // Clears all netescape state so a soft restart doesn't leave dangling
+  // references to closed/removed DOM elements.
+
+  function reset() {
+    isDialingUp = false;
+    ieWindowState = null;
+    currentUrl = DEFAULT_URL;
+    pageEl = null;
+    addressInput = null;
+    statusEl = null;
+    backBtn = null;
+    fwdBtn = null;
+    navHistory = [];
+    navIndex = -1;
+    currentParams = {};
+    if (freezeTimer)    { clearTimeout(freezeTimer);    freezeTimer = null;    }
+    if (pageLoadTimer)  { clearTimeout(pageLoadTimer);  pageLoadTimer = null;  }
+    if (pageLoadMidTimer) { clearTimeout(pageLoadMidTimer); pageLoadMidTimer = null; }
+  }
+
   // --- Public exports --------------------------------------------------
 
-  return { open: open, connect: connect };
+  return { open: open, connect: connect, reset: reset };
 
 }());

--- a/js/taskbar.js
+++ b/js/taskbar.js
@@ -1,0 +1,785 @@
+// taskbar.js — WinDoors 98 Start Menu
+// DOM built ONCE in init(), toggled on Start button click.
+// All delay values from window.APC.timing (win98-timing.js).
+// Submenus: Programs (app launcher), Documents (recent NetEscape history).
+// Keyboard: ArrowUp/Down moves items, Right opens submenu immediately,
+//           Left / Escape closes submenu / menu, Enter / Space activates item.
+// Namespaced under window.APC per project conventions.
+
+window.APC = window.APC || {};
+
+window.APC.taskbar = (function () {
+  'use strict';
+
+  // --- Module state ----------------------------------------------------
+
+  var startBtn = null;
+  var menuEl = null;
+
+  // Per-key open and close timer IDs for submenu hover behaviour.
+  var submenuOpenTimers  = {};
+  var submenuCloseTimers = {};
+
+  // Currently visible submenu element (null if none open).
+  var openSubmenuEl  = null;
+  var openSubmenuKey = null;
+
+  // --- Public API ------------------------------------------------------
+
+  function init() {
+    startBtn = document.getElementById('start-button');
+    menuEl   = document.getElementById('start-menu');
+    if (!startBtn || !menuEl) { return; }
+
+    buildMenu();
+    bindStartButton();
+    bindOutsideClick();
+    bindBeforeUnload();
+  }
+
+  // --- Build menu DOM (runs exactly once on init) ----------------------
+
+  function buildMenu() {
+    menuEl.innerHTML = '';
+
+    // Left gradient banner — "WinDoors 98" vertical text.
+    var banner = document.createElement('div');
+    banner.className = 'start-menu__banner';
+    banner.setAttribute('aria-hidden', 'true');
+    var bannerText = document.createElement('span');
+    bannerText.className = 'start-menu__banner-text';
+    bannerText.textContent = 'WinDoors 98';
+    banner.appendChild(bannerText);
+    menuEl.appendChild(banner);
+
+    // Items container — sits to the right of the banner.
+    var itemsEl = document.createElement('div');
+    itemsEl.className = 'start-menu__items';
+
+    var itemDefs = [
+      { key: 'programs',  label: 'Programs',  icon: '\uD83D\uDCC1', submenu: buildProgramsSubmenu  },
+      { key: 'documents', label: 'Documents', icon: '\uD83D\uDCC4', submenu: buildDocumentsSubmenu },
+      { key: 'settings',  label: 'Settings',  icon: '\u2699\uFE0F', disabled: true },
+      { key: 'find',      label: 'Find',       icon: '\uD83D\uDD0D', disabled: true },
+      { key: 'help',      label: 'Help',       icon: '\u2753',        action: showHelpStub },
+      { key: 'run',       label: 'Run\u2026',  icon: '\u25BA',        action: showRunStub },
+      { sep: true },
+      { key: 'shutdown',  label: 'Shut Down\u2026', icon: '\uD83D\uDD0C', action: showShutdownModal }
+    ];
+
+    itemDefs.forEach(function (def) {
+      if (def.sep) {
+        var sep = document.createElement('div');
+        sep.className = 'start-menu__separator';
+        sep.setAttribute('role', 'separator');
+        itemsEl.appendChild(sep);
+        return;
+      }
+      itemsEl.appendChild(buildMenuItem(def));
+    });
+
+    menuEl.appendChild(itemsEl);
+    setupMenuKeyboard(itemsEl);
+  }
+
+  // Builds a single top-level menu item element.
+  function buildMenuItem(def) {
+    var el = document.createElement('div');
+    el.className = 'start-menu__item' +
+      (def.disabled ? ' start-menu__item--disabled' : '');
+    el.setAttribute('role', 'menuitem');
+    el.setAttribute('tabindex', def.disabled ? '-1' : '0');
+    el.dataset.key = def.key;
+    if (def.disabled) { el.setAttribute('aria-disabled', 'true'); }
+
+    var iconSpan = document.createElement('span');
+    iconSpan.className = 'start-menu__item-icon';
+    iconSpan.setAttribute('aria-hidden', 'true');
+    iconSpan.textContent = def.icon || '';
+    el.appendChild(iconSpan);
+
+    var labelSpan = document.createElement('span');
+    labelSpan.className = 'start-menu__item-label';
+    labelSpan.textContent = def.label;
+    el.appendChild(labelSpan);
+
+    if (def.submenu) {
+      // ► arrow indicator
+      var arrowSpan = document.createElement('span');
+      arrowSpan.className = 'start-menu__item-arrow';
+      arrowSpan.setAttribute('aria-hidden', 'true');
+      arrowSpan.textContent = '\u25BA';
+      el.appendChild(arrowSpan);
+
+      el.setAttribute('aria-haspopup', 'menu');
+      el.setAttribute('aria-expanded', 'false');
+
+      var submenuEl = def.submenu();
+      submenuEl.dataset.parentKey = def.key;
+      el.appendChild(submenuEl);
+
+      attachSubmenuHover(def.key, el, submenuEl);
+
+    } else if (!def.disabled && def.action) {
+      el.addEventListener('click', function () {
+        var t = window.APC.timing;
+        setTimeout(function () {
+          closeMenu();
+          def.action();
+        }, t.rand(t.MENU_ACTION_MIN_MS, t.MENU_ACTION_MAX_MS));
+      });
+
+      el.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          el.click();
+        }
+      });
+    } else if (def.disabled) {
+      // Hovering over disabled item closes any open submenu
+      el.addEventListener('mouseenter', closeAllSubmenus);
+    }
+
+    // All non-submenu items close open submenus on hover
+    if (!def.submenu) {
+      el.addEventListener('mouseenter', closeAllSubmenus);
+    }
+
+    return el;
+  }
+
+  // --- Submenu hover timing --------------------------------------------
+  // Mouse hover uses MENU_SUBMENU_MIN/MAX_MS delay to open,
+  // SUBMENU_CLOSE_DELAY_MS delay to close (cancelled on mouse re-entry).
+  // Keyboard Right arrow opens immediately (no delay) — see setupMenuKeyboard.
+
+  function attachSubmenuHover(key, itemEl, submenuEl) {
+    itemEl.addEventListener('mouseenter', function () {
+      cancelSubmenuClose(key);
+      scheduleSubmenuOpen(key, itemEl, submenuEl);
+    });
+    itemEl.addEventListener('mouseleave', function () {
+      cancelSubmenuOpen(key);
+      scheduleSubmenuClose(key, itemEl, submenuEl);
+    });
+    // Keep submenu open while mouse is over it — cancel the close timer.
+    submenuEl.addEventListener('mouseenter', function () {
+      cancelSubmenuClose(key);
+    });
+    submenuEl.addEventListener('mouseleave', function () {
+      scheduleSubmenuClose(key, itemEl, submenuEl);
+    });
+  }
+
+  function scheduleSubmenuOpen(key, itemEl, submenuEl) {
+    var t = window.APC.timing;
+    submenuOpenTimers[key] = setTimeout(function () {
+      delete submenuOpenTimers[key];
+      openSubmenu(key, itemEl, submenuEl);
+    }, t.rand(t.MENU_SUBMENU_MIN_MS, t.MENU_SUBMENU_MAX_MS));
+  }
+
+  function cancelSubmenuOpen(key) {
+    if (submenuOpenTimers[key]) {
+      clearTimeout(submenuOpenTimers[key]);
+      delete submenuOpenTimers[key];
+    }
+  }
+
+  function scheduleSubmenuClose(key, itemEl, submenuEl) {
+    var t = window.APC.timing;
+    submenuCloseTimers[key] = setTimeout(function () {
+      delete submenuCloseTimers[key];
+      closeSubmenu(key, itemEl, submenuEl);
+    }, t.SUBMENU_CLOSE_DELAY_MS);
+  }
+
+  function cancelSubmenuClose(key) {
+    if (submenuCloseTimers[key]) {
+      clearTimeout(submenuCloseTimers[key]);
+      delete submenuCloseTimers[key];
+    }
+  }
+
+  function openSubmenu(key, itemEl, submenuEl) {
+    // Documents submenu is populated just-in-time from sessionStorage.
+    if (submenuEl.dataset.dynamic === 'documents') {
+      populateDocumentsSubmenu(submenuEl);
+    }
+
+    // Close any other open submenu first.
+    if (openSubmenuEl && openSubmenuEl !== submenuEl) {
+      var prevKey = openSubmenuKey;
+      var prevItem = menuEl.querySelector('[data-key="' + prevKey + '"]');
+      if (prevItem) { closeSubmenu(prevKey, prevItem, openSubmenuEl); }
+    }
+
+    submenuEl.classList.add('start-menu__submenu--open');
+    itemEl.setAttribute('aria-expanded', 'true');
+    itemEl.classList.add('start-menu__item--open');
+    openSubmenuEl  = submenuEl;
+    openSubmenuKey = key;
+  }
+
+  function closeSubmenu(key, itemEl, submenuEl) {
+    submenuEl.classList.remove('start-menu__submenu--open');
+    if (itemEl) {
+      itemEl.setAttribute('aria-expanded', 'false');
+      itemEl.classList.remove('start-menu__item--open');
+    }
+    if (openSubmenuEl === submenuEl) {
+      openSubmenuEl  = null;
+      openSubmenuKey = null;
+    }
+  }
+
+  function closeAllSubmenus() {
+    // Cancel all pending open timers.
+    Object.keys(submenuOpenTimers).forEach(function (k) {
+      clearTimeout(submenuOpenTimers[k]);
+      delete submenuOpenTimers[k];
+    });
+    // Close the currently visible submenu immediately.
+    if (openSubmenuEl && openSubmenuKey) {
+      var itemEl = menuEl.querySelector('[data-key="' + openSubmenuKey + '"]');
+      closeSubmenu(openSubmenuKey, itemEl, openSubmenuEl);
+    }
+  }
+
+  // --- Programs submenu -----------------------------------------------
+
+  function buildProgramsSubmenu() {
+    var sub = document.createElement('div');
+    sub.className = 'start-menu__submenu';
+    sub.setAttribute('role', 'menu');
+    sub.setAttribute('aria-label', 'Programs');
+
+    [
+      { app: 'winamp',      icon: '\uD83C\uDFB5', label: 'Winamp'      },
+      { app: 'minesweeper', icon: '\uD83D\uDCA3', label: 'Minesweeper' },
+      { app: 'calculator',  icon: '\uD83E\uDDF2', label: 'Calculator'  },
+      { app: 'notepad',     icon: '\uD83D\uDCDD', label: 'Notepad'     }
+    ].forEach(function (def) {
+      sub.appendChild(buildSubmenuItem(def.icon, def.label, function () {
+        if (window.APC.desktop && typeof window.APC.desktop.launchApp === 'function') {
+          window.APC.desktop.launchApp(def.app);
+        }
+      }));
+    });
+
+    return sub;
+  }
+
+  // --- Documents submenu (populated just-in-time) ---------------------
+
+  function buildDocumentsSubmenu() {
+    var sub = document.createElement('div');
+    sub.className = 'start-menu__submenu';
+    sub.setAttribute('role', 'menu');
+    sub.setAttribute('aria-label', 'Documents');
+    sub.dataset.dynamic = 'documents'; // signals openSubmenu() to repopulate
+    return sub;
+  }
+
+  function populateDocumentsSubmenu(sub) {
+    sub.innerHTML = '';
+
+    var hist = [];
+    try {
+      hist = JSON.parse(sessionStorage.getItem('ne_history') || '[]');
+    } catch (e) {}
+
+    if (!hist.length) {
+      var empty = document.createElement('div');
+      empty.className = 'start-menu__submenu-item start-menu__submenu-item--empty';
+      empty.setAttribute('role', 'menuitem');
+      empty.setAttribute('aria-disabled', 'true');
+      empty.textContent = '(No recent documents)';
+      sub.appendChild(empty);
+      return;
+    }
+
+    hist.slice(0, 10).forEach(function (url) {
+      sub.appendChild(buildSubmenuItem('\uD83C\uDF10', url, function () {
+        // Null-check: netescape.open() handles creating the window if not open.
+        if (window.APC.netescape && typeof window.APC.netescape.open === 'function') {
+          window.APC.netescape.open(url);
+        }
+      }));
+    });
+  }
+
+  // --- Submenu item helper --------------------------------------------
+
+  function buildSubmenuItem(icon, label, action) {
+    var el = document.createElement('div');
+    el.className = 'start-menu__submenu-item';
+    el.setAttribute('role', 'menuitem');
+    el.setAttribute('tabindex', '0');
+
+    var iconSpan = document.createElement('span');
+    iconSpan.className = 'start-menu__item-icon';
+    iconSpan.setAttribute('aria-hidden', 'true');
+    iconSpan.textContent = icon;
+    el.appendChild(iconSpan);
+
+    var labelSpan = document.createElement('span');
+    labelSpan.className = 'start-menu__item-label';
+    labelSpan.textContent = label;
+    el.appendChild(labelSpan);
+
+    el.addEventListener('click', function () {
+      var t = window.APC.timing;
+      setTimeout(function () {
+        closeMenu();
+        action();
+      }, t.rand(t.MENU_ACTION_MIN_MS, t.MENU_ACTION_MAX_MS));
+    });
+
+    el.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        el.click();
+      }
+      // Left arrow closes submenu and returns focus to parent item.
+      if (e.key === 'ArrowLeft' || e.key === 'Escape') {
+        e.preventDefault();
+        if (openSubmenuKey) {
+          var parentEl = menuEl.querySelector('[data-key="' + openSubmenuKey + '"]');
+          closeAllSubmenus();
+          if (parentEl) { parentEl.focus(); }
+        }
+      }
+    });
+
+    return el;
+  }
+
+  // --- Start button binding -------------------------------------------
+
+  function bindStartButton() {
+    startBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      if (menuEl.classList.contains('start-menu--open')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+
+    startBtn.addEventListener('keydown', function (e) {
+      if (e.key === 'ArrowUp' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        if (!menuEl.classList.contains('start-menu--open')) {
+          openMenu();
+        }
+        // Delay to let the open animation play, then focus first item.
+        setTimeout(function () {
+          var first = menuEl.querySelector(
+            '.start-menu__item:not(.start-menu__item--disabled)'
+          );
+          if (first) { first.focus(); }
+        }, window.APC.timing.MENU_OPEN_MAX_MS + 20);
+      }
+    });
+  }
+
+  function openMenu() {
+    var t = window.APC.timing;
+    var delay    = t.rand(t.MENU_OPEN_MIN_MS, t.MENU_OPEN_MAX_MS);
+    var willFlicker = Math.random() < t.MENU_FLICKER_CHANCE;
+
+    if (willFlicker) {
+      // Menu flickers open then immediately closes — user must click again.
+      menuEl.classList.add('start-menu--open');
+      startBtn.setAttribute('aria-expanded', 'true');
+      setTimeout(function () {
+        menuEl.classList.remove('start-menu--open');
+        startBtn.setAttribute('aria-expanded', 'false');
+      }, delay);
+      return;
+    }
+
+    setTimeout(function () {
+      menuEl.classList.add('start-menu--open');
+      startBtn.setAttribute('aria-expanded', 'true');
+    }, delay);
+  }
+
+  function closeMenu() {
+    menuEl.classList.remove('start-menu--open');
+    startBtn.setAttribute('aria-expanded', 'false');
+    closeAllSubmenus();
+    // Cancel any lingering close timers too.
+    Object.keys(submenuCloseTimers).forEach(function (k) {
+      clearTimeout(submenuCloseTimers[k]);
+      delete submenuCloseTimers[k];
+    });
+  }
+
+  // --- Outside-click and keyboard dismiss -----------------------------
+
+  function bindOutsideClick() {
+    document.addEventListener('click', function (e) {
+      if (menuEl.classList.contains('start-menu--open') &&
+          !menuEl.contains(e.target) && e.target !== startBtn) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && menuEl.classList.contains('start-menu--open')) {
+        closeMenu();
+        startBtn.focus();
+      }
+    });
+  }
+
+  // --- Keyboard navigation within the menu ---------------------------
+
+  function setupMenuKeyboard(itemsEl) {
+    itemsEl.addEventListener('keydown', function (e) {
+      var focusable = Array.prototype.slice.call(
+        itemsEl.querySelectorAll(
+          '.start-menu__item:not(.start-menu__item--disabled)'
+        )
+      );
+      var focused = document.activeElement;
+      var idx = focusable.indexOf(focused);
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        var next = focusable[(idx + 1) % focusable.length];
+        if (next) { next.focus(); }
+
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        var prev = focusable[(idx - 1 + focusable.length) % focusable.length];
+        if (prev) { prev.focus(); }
+
+      } else if (e.key === 'ArrowRight') {
+        // Open submenu immediately — no delay for keyboard (mouse uses timer).
+        if (focused && focused.dataset.key) {
+          var subEl = focused.querySelector('.start-menu__submenu');
+          if (subEl) {
+            e.preventDefault();
+            openSubmenu(focused.dataset.key, focused, subEl);
+            var firstSubItem = subEl.querySelector('.start-menu__submenu-item:not(.start-menu__submenu-item--empty)');
+            if (firstSubItem) { firstSubItem.focus(); }
+          }
+        }
+
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        closeAllSubmenus();
+
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        if (focused) {
+          e.preventDefault();
+          focused.click();
+        }
+      }
+    });
+  }
+
+  // --- Stub dialogs ---------------------------------------------------
+
+  function showHelpStub() {
+    showSimpleDialog('Windows Help',
+      'Windows Help is not available on this computer.');
+  }
+
+  function showRunStub() {
+    showSimpleDialog('Run',
+      'Type the name of a program, folder, or document,\n' +
+      'and Windows will open it for you.\n\n' +
+      '(This feature is not available.)');
+  }
+
+  // Reusable Win98-style message box: title + message + OK.
+  function showSimpleDialog(title, message) {
+    var overlay = document.createElement('div');
+    overlay.className = 'win98-msgbox-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', 'simple-dialog-title');
+
+    var box = document.createElement('div');
+    box.className = 'win98-msgbox';
+
+    var tb = buildTitlebar(title, 'simple-dialog-title', function () { dismiss(); });
+    box.appendChild(tb);
+
+    var body = document.createElement('div');
+    body.className = 'win98-msgbox__body';
+
+    var msg = document.createElement('p');
+    msg.className = 'win98-msgbox__msg';
+    // Preserve newlines as <br> — safe because textContent is used per segment.
+    message.split('\n').forEach(function (line, i) {
+      if (i > 0) { msg.appendChild(document.createElement('br')); }
+      msg.appendChild(document.createTextNode(line));
+    });
+    body.appendChild(msg);
+
+    var okBtn = document.createElement('button');
+    okBtn.className = 'win98-msgbox__ok';
+    okBtn.textContent = 'OK';
+    body.appendChild(okBtn);
+
+    box.appendChild(body);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+
+    function dismiss() {
+      if (overlay.parentNode) { overlay.parentNode.removeChild(overlay); }
+      document.removeEventListener('keydown', onKey);
+    }
+
+    var onKey = function (e) { if (e.key === 'Escape') { dismiss(); } };
+    document.addEventListener('keydown', onKey);
+    okBtn.addEventListener('click', dismiss);
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) { dismiss(); }
+    });
+
+    // Focus trap: only OK button + title close button to cycle.
+    trapFocusWithin(overlay);
+    okBtn.focus();
+  }
+
+  // --- Shutdown modal -------------------------------------------------
+
+  function showShutdownModal() {
+    var overlay = document.createElement('div');
+    overlay.className = 'win98-msgbox-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', 'shutdown-dialog-title');
+
+    var box = document.createElement('div');
+    box.className = 'win98-msgbox win98-msgbox--shutdown';
+
+    var tb = buildTitlebar(
+      'Shut Down WinDoors 98',
+      'shutdown-dialog-title',
+      function () { dismiss(); }
+    );
+    box.appendChild(tb);
+
+    var body = document.createElement('div');
+    body.className = 'win98-msgbox__body';
+
+    // Computer icon + prompt
+    var prompt = document.createElement('table');
+    prompt.className = 'shutdown-prompt';
+    prompt.setAttribute('cellpadding', '0');
+    prompt.setAttribute('cellspacing', '0');
+    var ptbody = document.createElement('tbody');
+    var ptr = document.createElement('tr');
+    var iconTd = document.createElement('td');
+    iconTd.className = 'shutdown-prompt__icon';
+    var iconEl = document.createElement('span');
+    iconEl.setAttribute('aria-hidden', 'true');
+    iconEl.textContent = '\uD83D\uDCBB';  // 💻
+    iconTd.appendChild(iconEl);
+    var textTd = document.createElement('td');
+    textTd.className = 'shutdown-prompt__text';
+    textTd.textContent = 'What do you want the computer to do?';
+    ptr.appendChild(iconTd);
+    ptr.appendChild(textTd);
+    ptbody.appendChild(ptr);
+    prompt.appendChild(ptbody);
+    body.appendChild(prompt);
+
+    // Radio options
+    var options = [
+      { value: 'shutdown',  label: 'Shut down'                                   },
+      { value: 'restart',   label: 'Restart the computer'                         },
+      { value: 'logoff',    label: 'Close all programs and log off as Atsushi'    }
+    ];
+
+    var radiosEl = document.createElement('div');
+    radiosEl.className = 'shutdown-radios';
+    var selectedValue = 'shutdown';
+
+    options.forEach(function (opt, i) {
+      var row = document.createElement('div');
+      row.className = 'shutdown-radio-row';
+
+      var radio = document.createElement('input');
+      radio.type  = 'radio';
+      radio.name  = 'shutdown-option';
+      radio.id    = 'shutdown-opt-' + opt.value;
+      radio.value = opt.value;
+      radio.className = 'shutdown-radio';
+      if (i === 0) { radio.checked = true; }
+
+      radio.addEventListener('change', function () {
+        if (radio.checked) { selectedValue = opt.value; }
+      });
+
+      var label = document.createElement('label');
+      label.setAttribute('for', 'shutdown-opt-' + opt.value);
+      label.className = 'shutdown-radio-label';
+      label.textContent = opt.label;
+
+      row.appendChild(radio);
+      row.appendChild(label);
+      radiosEl.appendChild(row);
+    });
+
+    body.appendChild(radiosEl);
+
+    // Buttons
+    var btnRow = document.createElement('div');
+    btnRow.className = 'win98-msgbox__body win98-msgbox__btnrow';
+
+    var okBtn     = buildDialogBtn('OK');
+    var cancelBtn = buildDialogBtn('Cancel');
+    var helpBtn   = buildDialogBtn('Help');
+
+    btnRow.appendChild(okBtn);
+    btnRow.appendChild(cancelBtn);
+    btnRow.appendChild(helpBtn);
+    body.appendChild(btnRow);
+
+    box.appendChild(body);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+
+    function dismiss() {
+      if (overlay.parentNode) { overlay.parentNode.removeChild(overlay); }
+      document.removeEventListener('keydown', onKey);
+    }
+
+    var onKey = function (e) { if (e.key === 'Escape') { dismiss(); } };
+    document.addEventListener('keydown', onKey);
+
+    okBtn.addEventListener('click', function () {
+      dismiss();
+      if (selectedValue === 'shutdown') {
+        window.APC.boot.shutdown();
+      } else if (selectedValue === 'restart') {
+        doRestart();
+      } else if (selectedValue === 'logoff') {
+        doLogOff();
+      }
+    });
+
+    cancelBtn.addEventListener('click', dismiss);
+
+    helpBtn.addEventListener('click', function () {
+      dismiss();
+      showHelpStub();
+    });
+
+    trapFocusWithin(overlay);
+    okBtn.focus();
+  }
+
+  function doRestart() {
+    if (window.umami) { window.umami.track('shutdown_trigger', { action: 'restart' }); }
+    // ~100ms tick lets the Umami call dispatch before state is cleared.
+    setTimeout(function () {
+      sessionStorage.clear();
+      if (window.APC.boot && typeof window.APC.boot.restart === 'function') {
+        window.APC.boot.restart();
+      }
+    }, 100);
+  }
+
+  function doLogOff() {
+    // Close all open windows.
+    if (window.APC.desktop && typeof window.APC.desktop.closeAll === 'function') {
+      window.APC.desktop.closeAll();
+    }
+    // Show sign-off dialog.
+    showSimpleDialog(
+      'Log Off WinDoors 98',
+      'Thanks for visiting. Close the tab whenever you\'re ready.'
+    );
+  }
+
+  // --- Dialog helpers -------------------------------------------------
+
+  // Builds a Win98-style titlebar with close button.
+  function buildTitlebar(title, titleId, onClose) {
+    var tb = document.createElement('div');
+    tb.className = 'win98-window__titlebar';
+
+    var titleSpan = document.createElement('span');
+    titleSpan.className = 'win98-window__title';
+    titleSpan.textContent = title;
+    if (titleId) { titleSpan.id = titleId; }
+    tb.appendChild(titleSpan);
+
+    var ctrls = document.createElement('span');
+    ctrls.className = 'win98-window__controls';
+    var xBtn = document.createElement('button');
+    xBtn.className = 'win98-window__btn';
+    xBtn.textContent = '\u00D7';
+    xBtn.setAttribute('aria-label', 'Close');
+    xBtn.addEventListener('click', onClose);
+    ctrls.appendChild(xBtn);
+    tb.appendChild(ctrls);
+
+    return tb;
+  }
+
+  // Builds a standard Win98 OK/Cancel/Help dialog button.
+  function buildDialogBtn(label) {
+    var btn = document.createElement('button');
+    btn.className = 'win98-msgbox__ok';
+    btn.textContent = label;
+    return btn;
+  }
+
+  // --- Focus trap (OS fidelity + WCAG 2.1 AA) ------------------------
+  // Confines Tab navigation to focusable elements inside `el`.
+
+  function trapFocusWithin(el) {
+    el.addEventListener('keydown', function (e) {
+      if (e.key !== 'Tab') { return; }
+      var focusable = Array.prototype.slice.call(
+        el.querySelectorAll('button, input, [tabindex="0"]')
+      ).filter(function (node) {
+        return !node.disabled && node.offsetParent !== null;
+      });
+      if (!focusable.length) { e.preventDefault(); return; }
+
+      var first = focusable[0];
+      var last  = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    });
+  }
+
+  // --- beforeunload ---------------------------------------------------
+  // Best-effort: navigator.sendBeacon() outlives the page unload where
+  // fetch()-based calls (umami.track) would be abandoned. Umami doesn't
+  // expose a sendBeacon API directly, so this is a documented no-op for now.
+  // The handler is here as the canonical place for future implementation.
+
+  function bindBeforeUnload() {
+    window.addEventListener('beforeunload', function () {
+      // navigator.sendBeacon(url, data) — best-effort, not guaranteed.
+      // Umami CDN script does not expose sendBeacon; upgrade if Umami adds it.
+    });
+  }
+
+  // --- Public export --------------------------------------------------
+
+  return { init: init };
+
+}());

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -100,6 +100,7 @@
     MENU_ACTION_MIN_MS:       100,  // item click → action fires
     MENU_ACTION_MAX_MS:       250,
     MENU_FLICKER_CHANCE:      1/12, // probability menu flickers closed on open
+    SUBMENU_CLOSE_DELAY_MS:    300, // delay before submenu closes after mouse leaves
 
     // -------------------------------------------------------------------------
     // Desktop App Launches  —  TEXTURE ZONE


### PR DESCRIPTION
## Summary

- **New `js/taskbar.js`** — WinDoors 98 Start Menu, DOM built once on `init()`, toggled by Start button click. Submenus: Programs (app launcher), Documents (recent NetEscape history from `sessionStorage['ne_history']`). Shut Down modal with 3 options.
- **Timing fidelity** — 80–180ms open delay, 1/12 flicker chance, 200–400ms submenu hover open, 300ms close delay cancelled on mouse re-entry. Keyboard `Right` opens submenus immediately (no delay).
- **Shut Down modal** — Shut Down (black "safe to turn off" overlay), Restart (soft `boot.restart()` — no `location.reload()`), Log Off (`desktop.closeAll()` + sign-off dialog: *"Thanks for visiting. Close the tab whenever you're ready."*).
- **`boot.js`** — adds `restart()` (full soft re-init: clears sessionStorage, resets all module state, replays gate → boot → desktop) and `shutdown()` (non-dismissable overlay).
- **`netescape.js`** — writes `sessionStorage['ne_history']` at end of `renderPage()` for Documents submenu; adds `reset()` for soft restart flow.
- **`desktop.js`** — hands Start button ownership to `taskbar.js`; exposes `launchApp`, `closeAll`, `reset` in public API.
- **`css/win98.css`** — full Start Menu styles: gradient banner, items, submenus, separator, Shut Down dialog. z-index 5000 above all other chrome layers (taskbar 999, context menu 2000, msgbox overlay 2999, tray popup 4000).
- **`CLAUDE.md`** — spec updated: Shut Down modal options documented (Log Off replaces MS-DOS mode — intentional permanent deviation), keyboard timing noted, `beforeunload` QA note added, stale `ie.js` references cleaned up, `taskbar.js` + `win98-timing.js` added to repo structure.

## Test plan

- [ ] Start button click opens menu after visible ~80–180ms delay
- [ ] 1-in-12 chance: menu flickers open then immediately closes (requires second click)
- [ ] Programs ► hover opens submenu after delay; keyboard `Right` opens immediately
- [ ] Mouse leaving item then re-entering cancels the 300ms close timer (submenu stays open)
- [ ] Clicking Winamp / Minesweeper / Calculator / Notepad in Programs submenu launches app with Texture Zone delay + hourglass cursor
- [ ] Documents ► shows "(No recent documents)" on first visit; after navigating NetEscape pages, shows up to 10 recent URLs
- [ ] Clicking a Document URL opens / focuses NetEscape and navigates to that page
- [ ] Help and Run… show stub dialogs; Escape and OK both close them
- [ ] Shut Down… opens modal with 3 radio options and OK/Cancel/Help buttons
- [ ] Tab key cycles only within the modal (focus trap); Escape closes modal
- [ ] Shut Down → OK: black "safe to turn off" overlay appears, no dismiss
- [ ] Restart → OK: fires `shutdown_trigger` Umami event, then gate screen replays cleanly (no stale windows visible after re-boot)
- [ ] Log Off → OK: closes all open windows, shows sign-off dialog
- [ ] Keyboard: `Tab` to Start button → `Enter` opens menu → `ArrowDown` moves focus → `ArrowRight` opens submenu → `Escape` closes submenu → `Escape` closes menu, focus returns to Start button
- [ ] Click outside open menu closes it
- [ ] No console errors in Chrome or Firefox

**QA note:** `beforeunload` Umami event is intentionally a no-op (Umami CDN lacks `sendBeacon` API). Missing events on tab close are expected — do not treat as a bug.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)