### PR TITLE
fix: Altcha base64url decode + unified deploy steps (guestbook hook)

### DIFF
--- a/pb_hooks/guestbook_verify.pb.js
+++ b/pb_hooks/guestbook_verify.pb.js
@@ -21,9 +21,17 @@
 // Required: 'altcha' text field in guestbook collection (stores the encoded payload).
 // Required: ALTCHA_HMAC_SECRET env var — loaded via EnvironmentFile in pocketbase.service.
 //
-// Deploy:
-//   cp pb_hooks/guestbook_verify.pb.js /home/atsushi/pocketbase/pb_hooks/
-//   sudo systemctl restart pocketbase
+// Deploy (run ALL steps in order — skipping any step can silently break submissions):
+//   1. Copy hook to Pi:
+//        cp pb_hooks/guestbook_verify.pb.js /home/atsushi/pocketbase/pb_hooks/
+//   2. Sync systemd service (required for ALTCHA_HMAC_SECRET to be loaded):
+//        scp config/pocketbase.service atsushispc:/etc/systemd/system/pocketbase.service
+//   3. Reload and restart PocketBase:
+//        ssh atsushispc 'sudo systemctl daemon-reload && sudo systemctl restart pocketbase'
+//
+// If step 2 is skipped and the Pi is still running the old service config,
+// $os.getenv('ALTCHA_HMAC_SECRET') returns undefined and every submission
+// returns 500, regardless of whether the hook JS is correct.
 
 // ---------------------------------------------------------------------------
 // Pure-JS base64 decoder — atob() is not available in PocketBase's JS runtime
@@ -32,7 +40,11 @@
 function base64Decode(str) {
   var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
   var out = '';
-  // Strip any characters that are not valid base64
+  // Normalise URL-safe base64 (Altcha uses - and _ instead of + and /)
+  // before stripping, otherwise hyphens and underscores are deleted and
+  // the decoded output is silently corrupted.
+  str = str.replace(/-/g, '+').replace(/_/g, '/');
+  // Strip any characters that are not valid standard base64
   str = str.replace(/[^A-Za-z0-9+/=]/g, '');
   var i = 0;
   while (i < str.length) {


### PR DESCRIPTION
## Summary

- **CRITICAL:** Adds URL-safe base64 normalisation (\`- → +\`, \`_ → /\`) in \`base64Decode()\` before the character-strip regex. Altcha encodes payloads with base64url; without this every \`-\` and \`_\` was silently deleted, corrupting the decoded JSON and causing every guestbook submission to fail with \`challenge mismatch\`.
- **HIGH:** Expands the deploy comment into a numbered 3-step checklist (hook copy → service file sync → systemd reload). The missing step 2 meant \`ALTCHA_HMAC_SECRET\` was never injected into PocketBase's environment, causing all submissions to return 500 even with a correct hook.

Closes #43
Closes #45

## Test plan

- [ ] Submit a guestbook entry end-to-end — Altcha widget solves, POST succeeds, entry lands in PocketBase with `approved: false`
- [ ] Confirm `ALTCHA_HMAC_SECRET` is set in `/home/atsushi/.env` on Pi
- [ ] Run the 3-step deploy checklist in the updated comment before testing
- [ ] Verify `sudo systemctl status pocketbase` shows the service running with the correct `EnvironmentFile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)