### PR TITLE
fix: use correct PocketBase 0.28 hook API (guestbook_verify.pb.js)

### DIFF
--- a/pb_hooks/guestbook_verify.pb.js
+++ b/pb_hooks/guestbook_verify.pb.js
@@ -1,15 +1,17 @@
 // pb_hooks/guestbook_verify.pb.js
 // Server-side Altcha proof-of-work verification for guestbook submissions.
-// Runs on every guestbook beforeCreate event; rejects any POST that does not
-// carry a valid, HMAC-signed Altcha payload.
+// Runs on every guestbook record create request; rejects any POST that does
+// not carry a valid, HMAC-signed Altcha payload.
 //
-// Verified against PocketBase 0.28.2 API:
-//   $app.onRecordBeforeCreateRequest(handler, 'collection')
+// PocketBase 0.28 API used:
+//   onRecordCreateRequest(handler, 'collection')
+//   e.record                       → the record being created (RequestEvent field)
+//   e.app                          → app instance (RequestEvent field)
+//   e.next()                       → proceed with record creation
 //   $security.sha256(text)         → hex SHA-256 string
 //   $security.hs256(text, key)     → hex HMAC-SHA256 string
 //   $os.getenv(key)                → environment variable string
 //   throw new BadRequestError(msg) → 400 response
-//   e.next()                       → proceed with record creation
 //
 // atob() and Buffer are NOT available in PocketBase's goja runtime.
 // base64Decode() below is a pure-JS implementation.
@@ -63,10 +65,10 @@ function base64Decode(str) {
 }
 
 // ---------------------------------------------------------------------------
-// Guestbook beforeCreate hook
+// Guestbook create hook
 // ---------------------------------------------------------------------------
 
-$app.onRecordBeforeCreateRequest(function (e) {
+onRecordCreateRequest((e) => {
   // 1. Read the submitted Altcha payload
   var payload = e.record.get('altcha');
   if (!payload) {


### PR DESCRIPTION
## Summary

The hook was registered with `$app.onRecordBeforeCreateRequest` — the wrong API for PocketBase 0.28. The correct hook for intercepting a record create API request is `onRecordCreateRequest`, called as a top-level function with the collection name as the second argument.

**Before:**
\`\`\`js
$app.onRecordBeforeCreateRequest(function (e) { ... }, 'guestbook');
\`\`\`

**After:**
\`\`\`js
onRecordCreateRequest((e) => { ... }, 'guestbook');
\`\`\`

All Altcha verification logic (base64url decode, challenge re-derivation, HMAC signature check) is unchanged.

## Test plan

- [ ] Deploy hook to Pi using the 3-step checklist in the file header
- [ ] Submit a guestbook entry — Altcha resolves, POST returns 200, entry appears in PocketBase with `approved: false`
- [ ] Submit with a tampered/missing Altcha payload — POST returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)