### PR TITLE
fix: read Altcha payload from hidden input, not widget .value (netescape.js)

### DIFF
--- a/js/netescape.js
+++ b/js/netescape.js
@@ -1096,9 +1096,14 @@ window.APC.netescape = (function () {
         approved: false
       };
       if (website) { payload.website = website; }
-      // Include Altcha PoW proof for future server-side HMAC verification.
-      var altchaValue = altchaWidget.value;
+      // Altcha injects a hidden input[name="altcha"] into the form after verification.
+      // Reading altchaWidget.value returns empty; the hidden input is the correct source.
+      var altchaHidden = form.querySelector('input[name="altcha"]');
+      var altchaValue = altchaHidden ? altchaHidden.value : '';
       if (altchaValue) { payload.altcha = altchaValue; }
+
+      console.log('[guestbook] submit payload:', JSON.stringify(payload));
+      console.log('[guestbook] altchaValue:', altchaValue);
 
       fetch(GUESTBOOK_API_URL, {
         method: 'POST',


### PR DESCRIPTION
## Summary

`altchaWidget.value` returns an empty string even after the Altcha widget verifies. The widget injects a hidden `<input name="altcha">` into the form upon verification — that's the correct source for the payload value.

**Before:**
\`\`\`js
var altchaValue = altchaWidget.value; // always empty
\`\`\`

**After:**
\`\`\`js
var altchaHidden = form.querySelector('input[name="altcha"]');
var altchaValue = altchaHidden ? altchaHidden.value : '';
\`\`\`

Also adds `console.log` before the fetch to confirm `altchaValue` is populated in devtools during testing.

## Test plan

- [ ] Open guestbook, solve Altcha widget
- [ ] Open devtools console, submit the form
- [ ] Confirm `[guestbook] altchaValue:` log shows a non-empty base64url string
- [ ] Confirm POST succeeds and entry lands in PocketBase

🤖 Generated with [Claude Code](https://claude.com/claude-code)