### PR TITLE
fix: CSP script-src header + reference-copy comment (config/Caddyfile)

### DIFF
--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -1,6 +1,13 @@
+# REFERENCE COPY — live file is /etc/caddy/Caddyfile on the Pi.
+# Sync manually after any edit:
+#   scp config/Caddyfile atsushispc:/etc/caddy/Caddyfile
+#   ssh atsushispc 'sudo systemctl reload caddy'
+
 :80 {
     root * /home/atsushi/site
     file_server
+
+    header Content-Security-Policy "script-src 'self' https://cloud.umami.is https://cdn.jsdelivr.net"
 
     header /js/* Cache-Control "no-cache, must-revalidate"
     header /css/* Cache-Control "no-cache, must-revalidate"


### PR DESCRIPTION
## Summary

- **Closes #68:** Adds `Content-Security-Policy` header to the Caddy site block covering the three known script sources:
  - `'self'` — the site's own JS files
  - `https://cloud.umami.is` — Umami analytics script
  - `https://cdn.jsdelivr.net` — Altcha web component widget

- **Closes #49:** Adds a top-of-file comment making it explicit that this is a reference copy, with the exact scp + reload commands needed to sync to the live Pi.

## Manual deploy required after merge

\`\`\`bash
scp config/Caddyfile atsushispc:/etc/caddy/Caddyfile
ssh atsushispc 'sudo systemctl reload caddy'
\`\`\`

## Test plan

- [ ] After syncing to Pi, verify Altcha widget loads (CSP allows `cdn.jsdelivr.net`)
- [ ] Verify Umami script loads (CSP allows `cloud.umami.is`)
- [ ] Check browser devtools console for any CSP violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)