### PR TITLE
fix: tray popup timer leak, aria-live region, dismiss race (widgets.js)

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -570,6 +570,9 @@ window.APC.boot = (function () {
     if (window.APC.desktop && typeof window.APC.desktop.reset === 'function') {
       window.APC.desktop.reset();
     }
+    if (window.APC.widgets && typeof window.APC.widgets.reset === 'function') {
+      window.APC.widgets.reset();
+    }
 
     // Clear session keys so init() runs the full sequence.
     sessionStorage.removeItem('boot_complete');

--- a/js/widgets.js
+++ b/js/widgets.js
@@ -107,6 +107,10 @@ window.APC.widgets = (function () {
   // --- Tray pop-up state ----------------------------------------------
 
   var trayPopupTimer = null;
+  // Persistent ARIA live region — appended once on init, mutated per popup.
+  // Appending an already-populated element does not reliably trigger screen
+  // readers; mutating a pre-existing region does.
+  var liveRegion = null;
 
   // --- RAM widget -----------------------------------------------------
 
@@ -182,6 +186,19 @@ window.APC.widgets = (function () {
   // Close button has TRAY_CLICK ms response delay per the timing spec.
 
   function initTrayPopups() {
+    // Create a single persistent live region so screen readers reliably
+    // announce tray notifications. Must be in the DOM before text is set.
+    liveRegion = document.createElement('div');
+    liveRegion.setAttribute('role', 'status');
+    liveRegion.setAttribute('aria-live', 'polite');
+    liveRegion.setAttribute('aria-atomic', 'true');
+    liveRegion.style.position = 'absolute';
+    liveRegion.style.width = '1px';
+    liveRegion.style.height = '1px';
+    liveRegion.style.overflow = 'hidden';
+    liveRegion.style.clip = 'rect(0,0,0,0)';
+    liveRegion.style.whiteSpace = 'nowrap';
+    document.body.appendChild(liveRegion);
     scheduleTrayPopup();
   }
 
@@ -202,8 +219,6 @@ window.APC.widgets = (function () {
 
     var popup = document.createElement('div');
     popup.className = 'win98-tray-popup';
-    popup.setAttribute('role', 'alert');
-    popup.setAttribute('aria-live', 'assertive');
 
     var msgEl = document.createElement('span');
     msgEl.className = 'win98-tray-popup__msg';
@@ -218,11 +233,19 @@ window.APC.widgets = (function () {
     popup.appendChild(closeBtn);
     document.body.appendChild(popup);
 
+    // Announce via the persistent live region (mutating pre-existing region
+    // is reliable; appending a populated element with aria-live is not).
+    if (liveRegion) { liveRegion.textContent = message; }
+
+    var dismissed = false;
     var autoTimer = setTimeout(dismiss, t.rand(t.TRAY_POPUP_DISPLAY_MIN_MS, t.TRAY_POPUP_DISPLAY_MAX_MS));
 
     function dismiss() {
+      if (dismissed) { return; }
+      dismissed = true;
       clearTimeout(autoTimer);
       if (popup.parentNode) { popup.parentNode.removeChild(popup); }
+      if (liveRegion) { liveRegion.textContent = ''; }
     }
 
     // TRAY_CLICK_MIN/MAX delay on close button response (Texture Zone tray click latency)
@@ -296,6 +319,14 @@ window.APC.widgets = (function () {
     initTrayPopups();
   }
 
-  return { init: init };
+  // Called by boot.restart() to cancel any in-flight popup timer so soft
+  // restarts don't accumulate parallel popup chains.
+  function reset() {
+    clearTimeout(trayPopupTimer);
+    trayPopupTimer = null;
+    if (liveRegion) { liveRegion.textContent = ''; }
+  }
+
+  return { init: init, reset: reset };
 
 }());


### PR DESCRIPTION
## Summary

Three fixes in `js/widgets.js` + one call added to `js/boot.js`.

**Closes #44 — HIGH: trayPopupTimer leaks across soft restarts**
Exposes `widgets.reset()` that cancels `trayPopupTimer` and clears the live region. `boot.restart()` now calls it alongside the existing `netescape.reset()` and `desktop.reset()` calls. Without this, each soft restart spawned a new popup schedule on top of old ones — after 3 restarts, popups fired 4× as often.

**Closes #53 — MEDIUM: ARIA live region not reliably announced**
Replaces the per-popup `role="alert"` / `aria-live="assertive"` attributes (set on a node before it's in the DOM) with a single persistent `role="status"` / `aria-live="polite"` region appended to `body` on init. `showTrayPopup` now mutates `liveRegion.textContent` directly — mutations to a pre-existing live region are reliably picked up by screen readers.

**Closes #62 — LOW: close/destroy race in dismiss()**
Adds a `dismissed` boolean flag inside `showTrayPopup`. `dismiss()` returns immediately if already called, making concurrent `autoTimer` + click-handler invocations fully idempotent — no double `removeChild`, no `clearTimeout` on an already-fired timer.

## Test plan

- [ ] Trigger Start → Restart multiple times; confirm tray popups fire at normal frequency, not exponentially increasing
- [ ] Use a screen reader (VoiceOver / NVDA) — tray notification text should be announced when popup appears
- [ ] Click the close button exactly as the auto-dismiss timer fires — no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)