### PR TITLE
fix: restart session contract + shutdown button row class (taskbar.js)

### DIFF
--- a/js/taskbar.js
+++ b/js/taskbar.js
@@ -633,7 +633,7 @@ window.APC.taskbar = (function () {
 
     // Buttons
     var btnRow = document.createElement('div');
-    btnRow.className = 'win98-msgbox__body win98-msgbox__btnrow';
+    btnRow.className = 'win98-msgbox__btnrow';
 
     var okBtn     = buildDialogBtn('OK');
     var cancelBtn = buildDialogBtn('Cancel');
@@ -682,7 +682,11 @@ window.APC.taskbar = (function () {
     if (window.umami) { window.umami.track('shutdown_trigger', { action: 'restart' }); }
     // ~100ms tick lets the Umami call dispatch before state is cleared.
     setTimeout(function () {
-      sessionStorage.clear();
+      // Remove only the keys this restart flow owns. sessionStorage.clear()
+      // would wipe unrelated state (audio unlock, resume gate) and conflicts
+      // with boot.restart() which also removes these keys explicitly.
+      sessionStorage.removeItem('boot_complete');
+      sessionStorage.removeItem('ne_history');
       if (window.APC.boot && typeof window.APC.boot.restart === 'function') {
         window.APC.boot.restart();
       }


### PR DESCRIPTION
## Summary

**Closes #52 — MEDIUM: double sessionStorage.clear() with no contract**
Replaces `sessionStorage.clear()` in `doRestart()` with two targeted `removeItem` calls for `'boot_complete'` and `'ne_history'` — the only keys the restart flow should own. The blanket clear was silently wiping unrelated session state (audio unlock, resume gate flag) and duplicating removes that `boot.restart()` already performs explicitly.

**Closes #57 — LOW: shutdown dialog button row misaligned**
Removes `win98-msgbox__body` from `btnRow.className` in `showShutdownModal()`. That class applies body-level padding and margin unsuitable for a button row, pushing OK/Cancel/Help out of alignment. `win98-msgbox__btnrow` alone is the correct class.

## Test plan

- [ ] Open Start → Shut Down → Restart — soft boot completes, desktop returns cleanly
- [ ] After restart, confirm audio still works (audio unlock state preserved)
- [ ] Open Start → Shut Down — OK/Cancel/Help buttons are evenly aligned in the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)