### PR TITLE
fix: freeze dialog scope, toolbar separator class, cap comment (netescape.js)

### DIFF
--- a/css/netescape-base.css
+++ b/css/netescape-base.css
@@ -395,7 +395,7 @@
 --------------------------------------------------------------- */
 
 .netescape-freeze-dialog {
-  position: fixed;
+  position: absolute;  /* relative to .netescape-chrome (position:relative) */
   top: 0;
   left: 0;
   right: 0;

--- a/js/netescape.js
+++ b/js/netescape.js
@@ -236,7 +236,7 @@ window.APC.netescape = (function () {
 
     // Vertical separator
     const tdSep = document.createElement('td');
-    tdSep.className = 'netescape-chrome__toolbar-cell ie-chrome__toolbar-sep';
+    tdSep.className = 'netescape-chrome__toolbar-cell netescape-chrome__toolbar-sep';
     tr.appendChild(tdSep);
 
     // "Address" label
@@ -433,7 +433,8 @@ window.APC.netescape = (function () {
   }
 
   // startPageLoad — runs the Protected Path status bar sequence then renders the page.
-  // delay is capped at 1000ms (Protected Path rule: max 1s, no failures).
+  // delay is capped at 1000ms — this limits the renderPage portion only, not the
+  // full end-to-end navigation time (dial-up simulation adds on top of this).
   function startPageLoad(url, pageKey, delay) {
     cancelPageLoad();
     var capped = Math.min(delay, 1000);
@@ -1404,7 +1405,11 @@ window.APC.netescape = (function () {
     footer.appendChild(cancelBtn);
     win.appendChild(footer);
     overlay.appendChild(win);
-    document.body.appendChild(overlay);
+    // Append inside the chrome container, not document.body. position:absolute
+    // (set in CSS) scopes the overlay to the NetEscape window rather than the
+    // full viewport, so other open desktop windows remain accessible.
+    var freezeContainer = (pageEl && pageEl.parentNode) ? pageEl.parentNode : document.body;
+    freezeContainer.appendChild(overlay);
 
     // Focus OK button for keyboard accessibility.
     okBtn.focus();


### PR DESCRIPTION
## Summary

**Closes #47 — HIGH: freeze dialog overlays entire viewport**
Appends the freeze dialog overlay to `pageEl.parentNode` (`.netescape-chrome`, which has `position: relative`) instead of `document.body`. Also changes `.netescape-freeze-dialog` in CSS from `position: fixed` to `position: absolute` — without this CSS change, `fixed` positioning ignores the containing block and the overlay would still cover the whole viewport regardless of where it's appended. The dialog now blocks only the NetEscape window; the taskbar and other open apps stay accessible.

**Closes #50 — MEDIUM: toolbar separator has orphaned ie- class**
Renames `ie-chrome__toolbar-sep` → `netescape-chrome__toolbar-sep` in `buildToolbar()`. The old class was removed during the PR #25 CSS rename, leaving the separator unstyled.

**Closes #58 — LOW: startPageLoad comment implies full Protected Path compliance**
Updates the comment on the `Math.min(delay, 1000)` cap to clarify it limits the `renderPage` delay only — dial-up simulation time adds on top and is not bounded by this cap.

## Files changed
- `js/netescape.js`
- `css/netescape-base.css` (CSS positioning change required for #47)

## Test plan

- [ ] Enter an unknown URL in the address bar — freeze dialog appears inside the NetEscape window only, not covering the taskbar or other open windows
- [ ] Toolbar separator line is visible between nav buttons and address bar
- [ ] Cancel/OK on freeze dialog work correctly; overlay removes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)