### PR TITLE
fix: identity line resize, mobile detection, timing guard (boot.js)

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -53,12 +53,18 @@ window.APC.boot = (function () {
   // --- Mobile detection ----------------------------------------------------
 
   function isMobileOrTouch() {
-    // Both conditions must be true: genuine touch hardware (maxTouchPoints > 1)
-    // AND a physically small screen (screen.width, not window.innerWidth).
-    // Using screen.width prevents false positives on laptops with small windows.
-    // maxTouchPoints > 1 (not > 0) excludes laptops that report a single
-    // touch point for Force Touch / precision touchpad on macOS.
-    return navigator.maxTouchPoints > 1 && screen.width < 1024;
+    // All three conditions must be true:
+    // 1. Genuine touch hardware (maxTouchPoints > 1).
+    //    > 1 (not > 0) excludes macOS Force Touch / precision touchpad.
+    // 2. Physically small screen (screen.width < 1024).
+    //    screen.width (not window.innerWidth) avoids false positives on
+    //    laptops with small browser windows.
+    // 3. No fine pointer (mouse / trackpad).
+    //    Excludes docked tablets and small desktop monitors that have a
+    //    touch layer but are primarily operated with a precise pointer.
+    return navigator.maxTouchPoints > 1 &&
+           screen.width < 1024 &&
+           !window.matchMedia('(pointer: fine)').matches;
   }
 
   function showMobileInterstitial() {
@@ -244,12 +250,10 @@ window.APC.boot = (function () {
 
   function startIdentityLines() {
     if (hasStarted) { return; }
-    const rows = Math.floor(canvas.height / FONT_SIZE);
-    // Anchor roughly 42% down the screen — prompt at 50% will sit below.
-    const anchorRow = Math.floor(rows * 0.42);
+    // identityX is constant (no dependency on canvas dimensions).
+    // identityY1/Y2 are recalculated each frame in drawFrame() so they
+    // stay accurate if the window is resized between now and draw time.
     identityX  = 2 * FONT_SIZE;
-    identityY1 = (anchorRow + 1) * FONT_SIZE;
-    identityY2 = (anchorRow + 2) * FONT_SIZE;
     identityPhase = 'line1';
     typeNextChar();
   }
@@ -394,7 +398,12 @@ window.APC.boot = (function () {
 
     // Redraw typed identity lines at full brightness each frame so the fade
     // overlay doesn't dim them while they're still being typed.
+    // Y positions recalculated here so a window resize between startIdentityLines()
+    // and this frame doesn't leave the text at a stale vertical position.
     if (identityPhase !== 'waiting') {
+      const anchorRow = Math.floor(Math.floor(canvas.height / FONT_SIZE) * 0.42);
+      identityY1 = (anchorRow + 1) * FONT_SIZE;
+      identityY2 = (anchorRow + 2) * FONT_SIZE;
       ctx.font = FONT_SIZE + 'px "Courier New", monospace';
       ctx.fillStyle = MATRIX_COLOR;
       if (identityTyped1) {
@@ -463,6 +472,10 @@ window.APC.boot = (function () {
   }
 
   function animateProgressBar() {
+    // Guard: if win98-timing.js failed to load, BOOT_BLOCK_COUNT is undefined.
+    // Without this, addBlock() would see blocksFilled >= undefined (false forever)
+    // and loop indefinitely, or NaN arithmetic would break the progress display.
+    if (!window.APC.timing || !window.APC.timing.BOOT_BLOCK_COUNT) { return; }
     const t = window.APC.timing;
     const track = document.getElementById('boot-progress-track');
     let blocksFilled = 0;


### PR DESCRIPTION
## Summary

**Closes #55 — MEDIUM: identity line Y positions stale after canvas resize**
`identityY1` and `identityY2` were computed once in `startIdentityLines()` at the 2-second mark. If the user resized the browser window before or during the animation, the stored values became stale and the lines drew at the wrong vertical position until the next full boot. Fix: remove the Y calculations from `startIdentityLines()` and recompute them at the top of the identity-drawing section in `drawFrame()` using the current `canvas.height` on every frame.

**Closes #56 — MEDIUM: mobile gate false-positives on small desktop monitors**
`isMobileOrTouch()` checked only `maxTouchPoints > 1 && screen.width < 1024`. Devices like docked tablets or small external monitors with touch layers but a mouse attached would be incorrectly blocked. Adding `!window.matchMedia('(pointer: fine)').matches` ensures the gate only fires for truly touch-primary devices — if a fine pointer (mouse/trackpad) is present, the desktop experience is allowed regardless of screen size.

**Closes #63 — LOW: no fallback if win98-timing.js fails to load**
`animateProgressBar()` immediately references `t.BOOT_BLOCK_COUNT`. If `win98-timing.js` fails to load (script error, network issue), `window.APC.timing` is undefined and every comparison against `BOOT_BLOCK_COUNT` produces `NaN`, either breaking the progress display or causing `addBlock()` to loop without terminating. Added an early-return guard at the top of the function.

## Test plan

- [ ] Load the site, let Matrix rain play, then resize the browser window mid-animation — identity lines stay correctly positioned
- [ ] Open on a desktop browser at viewport < 1024px wide — desktop experience loads (no mobile interstitial)
- [ ] Open on a touch-primary mobile device — interstitial correctly appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)