### PR TITLE
fix(csp): add unsafe-inline to script-src

### DIFF
--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -7,7 +7,7 @@
     root * /home/atsushi/site
     file_server
 
-    header Content-Security-Policy "script-src 'self' https://cloud.umami.is https://cdn.jsdelivr.net"
+    header Content-Security-Policy "script-src 'self' 'unsafe-inline' https://cloud.umami.is https://cdn.jsdelivr.net"
 
     header /js/* Cache-Control "no-cache, must-revalidate"
     header /css/* Cache-Control "no-cache, must-revalidate"


### PR DESCRIPTION
## Summary

- Adds `'unsafe-inline'` to the `script-src` CSP directive in `config/Caddyfile`
- Unblocks inline `<script>` tags in HTML files (e.g. `window.APC.boot.init()` in `index.html`)

## Post-merge Pi steps (manual)

```bash
scp config/Caddyfile atsushispc:/etc/caddy/Caddyfile
ssh atsushispc 'sudo systemctl reload caddy'
```

## Test plan

- [ ] After Pi sync, open DevTools → Console on ahisaka.com — no CSP violations
- [ ] Matrix rain starts (confirms `init()` is no longer blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)