### PR TITLE
Feature: XP-style tray balloon system

### DIFF
--- a/css/win98.css
+++ b/css/win98.css
@@ -1096,3 +1096,128 @@
   outline: 1px dotted #000000;
   outline-offset: -2px;
 }
+
+/* ----------------------------------------------------------------
+   XP-style Tray Balloon
+   Exception to no-border-radius rule: balloon is XP chrome, not
+   Win98 chrome. Positioned fixed bottom-right, above taskbar.
+   CSS transition drives entry (translateY + opacity) and exit
+   (opacity only). Triangle tail is a pure-CSS pseudo-element.
+   Z-index 4000 normally; 998 during behind-taskbar glitch.
+---------------------------------------------------------------- */
+
+.tray-balloon {
+  position: fixed;
+  bottom: 40px;
+  right: 8px;
+  width: 248px;
+  background: #FFFFCC;
+  border: 1px solid #000000;
+  border-radius: 6px;
+  z-index: 4000;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 150ms ease, transform 150ms ease;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+  font-size: 11px;
+  color: #000000;
+}
+
+.tray-balloon--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.tray-balloon--exit {
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+
+/* Triangle tail pointing down toward taskbar */
+.tray-balloon::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  right: 16px;
+  width: 0;
+  height: 0;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-top: 8px solid #000000;
+}
+
+.tray-balloon::before {
+  content: '';
+  position: absolute;
+  bottom: -7px;
+  right: 17px;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid #FFFFCC;
+  z-index: 1;
+}
+
+.tray-balloon__header {
+  background: linear-gradient(to right, #0A246A, #A6CAF0);
+  border-radius: 5px 5px 0 0;
+  padding: 3px 6px;
+  display: block;
+  overflow: hidden;
+}
+
+.tray-balloon__icon {
+  float: left;
+  margin-right: 4px;
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.tray-balloon__title {
+  float: left;
+  color: #FFFFFF;
+  font-weight: bold;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tray-balloon__close {
+  float: right;
+  width: 14px;
+  height: 14px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: #FFFFFF;
+  font-size: 10px;
+  line-height: 12px;
+  text-align: center;
+  cursor: pointer;
+  padding: 0;
+  font-family: 'MS Sans Serif', Tahoma, sans-serif;
+}
+
+.tray-balloon__close:hover {
+  border-color: #FFFFFF;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.tray-balloon__close:focus {
+  outline: 1px dotted #FFFFFF;
+  outline-offset: -2px;
+}
+
+.tray-balloon__body {
+  display: block;
+  padding: 6px 8px 8px;
+  cursor: pointer;
+  line-height: 1.4;
+  clear: both;
+}
+
+.tray-balloon__body:hover {
+  text-decoration: underline;
+}

--- a/js/widgets.js
+++ b/js/widgets.js
@@ -104,13 +104,51 @@ window.APC.widgets = (function () {
       });
   }
 
-  // --- Tray pop-up state ----------------------------------------------
+  // --- Tray balloon state ---------------------------------------------
+  // XP-style balloon notifications. Two types alternate (never random) —
+  // Low Disk Space and Security Risk. Suppressed while a balloon is visible
+  // or while Protected Path is active (window.APC.session.protectedPathActive).
 
-  var trayPopupTimer = null;
-  // Persistent ARIA live region — appended once on init, mutated per popup.
-  // Appending an already-populated element does not reliably trigger screen
-  // readers; mutating a pre-existing region does.
+  var isBalloonVisible = false;    // prevents overlapping balloons
+  var balloonTypeIndex = 0;        // alternates through BALLOON_TYPES
+  var currentBalloon = null;       // live DOM element (or null)
+  var trayPopupTimer = null;       // inter-balloon schedule timer
+  var autoTimerId = null;          // auto-dismiss timer for live balloon
+  var glitchTimerId = null;        // self-correct timer for behind-taskbar glitch
+  // Persistent ARIA live region — appended once on init, mutated per balloon.
   var liveRegion = null;
+
+  // Disk Cleanup body click handler — stubbed until spec 24c49bfe arrives
+  function handleLowDiskClick() {
+    // TODO: Disk Cleanup click path
+    // Spec: Disk Cleanup Feature Spec (document 24c49bfe)
+    // On body click: apply TRAY_CLICK_MIN/MAX_MS delay → isBalloonVisible = false → open Disk Cleanup modal
+    // Do not implement until spec is provided. Do not stub with a placeholder modal.
+  }
+
+  function handleSecurityRiskClick() {
+    showWidgetModal('Security Center', 'No threats detected. Atsushi\u2019s code is clean.');
+    if (window.umami) {
+      window.umami.track('tray_balloon_action', { balloon_type: 'security_risk' });
+    }
+  }
+
+  var BALLOON_TYPES = [
+    {
+      type: 'low_disk_space',
+      icon: '\u26A0\uFE0F',
+      title: 'Low Disk Space',
+      body: 'You are running low on disk space on Local Disk (C:). Click here to see if you can free space on this drive.',
+      onBodyClick: handleLowDiskClick
+    },
+    {
+      type: 'security_risk',
+      icon: '\uD83D\uDEE1\uFE0F',
+      title: 'Your computer may be at risk',
+      body: 'Antivirus software might not be installed. Click this balloon to fix this problem.',
+      onBodyClick: handleSecurityRiskClick
+    }
+  ];
 
   // --- RAM widget -----------------------------------------------------
 
@@ -180,14 +218,17 @@ window.APC.widgets = (function () {
     });
   }
 
-  // --- Tray pop-ups  (Texture Zone) -----------------------------------
-  // Simulates Win98 security/system notifications from the notification area.
-  // Fires every TRAY_POPUP_MIN–MAX ms; each balloon stays for TRAY_POPUP_DISPLAY ms.
-  // Close button has TRAY_CLICK ms response delay per the timing spec.
+  // --- Tray balloons  (Texture Zone) ----------------------------------
+  // XP-style balloon notifications from the notification area.
+  // Types alternate: Low Disk Space → Security Risk → repeat.
+  // Suppressed while balloon is visible or Protected Path is active.
+  // Behind-taskbar glitch fires 1-in-20: renders at z-index 998 (below
+  // taskbar at 999) then self-corrects after TRAY_BALLOON_GLITCH_MIN/MAX ms.
 
   function initTrayPopups() {
-    // Create a single persistent live region so screen readers reliably
-    // announce tray notifications. Must be in the DOM before text is set.
+    // Persistent ARIA live region — must exist before text is set.
+    // Mutating a pre-existing region is reliable; appending a new
+    // populated aria-live element is not.
     liveRegion = document.createElement('div');
     liveRegion.setAttribute('role', 'status');
     liveRegion.setAttribute('aria-live', 'polite');
@@ -205,53 +246,124 @@ window.APC.widgets = (function () {
   function scheduleTrayPopup() {
     var t = window.APC.timing;
     trayPopupTimer = setTimeout(function () {
-      var messages = [
-        'Your computer may be at risk.',
-        'Low disk space on C:'
-      ];
-      showTrayPopup(messages[Math.floor(Math.random() * messages.length)]);
+      var session = window.APC && window.APC.session;
+      // Skip if a balloon is already up or Protected Path is active
+      if (!isBalloonVisible && !(session && session.protectedPathActive)) {
+        showTrayBalloon(BALLOON_TYPES[balloonTypeIndex % BALLOON_TYPES.length]);
+        balloonTypeIndex++;
+      }
       scheduleTrayPopup();
     }, t.rand(t.TRAY_POPUP_MIN_MS, t.TRAY_POPUP_MAX_MS));
   }
 
-  function showTrayPopup(message) {
+  function showTrayBalloon(spec) {
     var t = window.APC.timing;
+    isBalloonVisible = true;
 
-    var popup = document.createElement('div');
-    popup.className = 'win98-tray-popup';
+    // Build XP balloon DOM
+    var balloon = document.createElement('div');
+    balloon.className = 'tray-balloon';
+    balloon.setAttribute('role', 'alert');
+    balloon.setAttribute('aria-label', spec.title + ': ' + spec.body);
 
-    var msgEl = document.createElement('span');
-    msgEl.className = 'win98-tray-popup__msg';
-    msgEl.textContent = message;
+    var header = document.createElement('div');
+    header.className = 'tray-balloon__header';
+
+    var iconEl = document.createElement('span');
+    iconEl.className = 'tray-balloon__icon';
+    iconEl.setAttribute('aria-hidden', 'true');
+    iconEl.textContent = spec.icon;
+
+    var titleEl = document.createElement('span');
+    titleEl.className = 'tray-balloon__title';
+    titleEl.textContent = spec.title;
 
     var closeBtn = document.createElement('button');
-    closeBtn.className = 'win98-tray-popup__close';
+    closeBtn.className = 'tray-balloon__close';
     closeBtn.textContent = '\u00D7';
-    closeBtn.setAttribute('aria-label', 'Dismiss notification');
+    closeBtn.setAttribute('aria-label', 'Dismiss');
 
-    popup.appendChild(msgEl);
-    popup.appendChild(closeBtn);
-    document.body.appendChild(popup);
+    header.appendChild(iconEl);
+    header.appendChild(titleEl);
+    header.appendChild(closeBtn);
 
-    // Announce via the persistent live region (mutating pre-existing region
-    // is reliable; appending a populated element with aria-live is not).
-    if (liveRegion) { liveRegion.textContent = message; }
+    var bodyEl = document.createElement('div');
+    bodyEl.className = 'tray-balloon__body';
+    bodyEl.textContent = spec.body;
 
-    var dismissed = false;
-    var autoTimer = setTimeout(dismiss, t.rand(t.TRAY_POPUP_DISPLAY_MIN_MS, t.TRAY_POPUP_DISPLAY_MAX_MS));
+    balloon.appendChild(header);
+    balloon.appendChild(bodyEl);
+    document.body.appendChild(balloon);
+    currentBalloon = balloon;
 
-    function dismiss() {
-      if (dismissed) { return; }
-      dismissed = true;
-      clearTimeout(autoTimer);
-      if (popup.parentNode) { popup.parentNode.removeChild(popup); }
-      if (liveRegion) { liveRegion.textContent = ''; }
+    // Behind-taskbar glitch: 1-in-20 chance renders below taskbar (z-index 998)
+    // Self-corrects after TRAY_BALLOON_GLITCH_MIN/MAX ms
+    if (Math.random() < t.TRAY_BALLOON_GLITCH_CHANCE) {
+      balloon.style.zIndex = t.TRAY_BALLOON_GLITCH_Z_INDEX;
+      glitchTimerId = setTimeout(function () {
+        if (balloon.parentNode) { balloon.style.zIndex = t.TRAY_BALLOON_Z_INDEX; }
+        glitchTimerId = null;
+      }, t.rand(t.TRAY_BALLOON_GLITCH_MIN_MS, t.TRAY_BALLOON_GLITCH_MAX_MS));
     }
 
-    // TRAY_CLICK_MIN/MAX delay on close button response (Texture Zone tray click latency)
-    closeBtn.addEventListener('click', function () {
-      setTimeout(dismiss, t.rand(t.TRAY_CLICK_MIN_MS, t.TRAY_CLICK_MAX_MS));
+    // Double-rAF: browser must lay out the element before the --visible class
+    // triggers the CSS transition; single rAF is not reliable across all engines.
+    requestAnimationFrame(function () {
+      requestAnimationFrame(function () {
+        balloon.classList.add('tray-balloon--visible');
+      });
     });
+
+    // Announce via persistent live region
+    if (liveRegion) { liveRegion.textContent = spec.title + ': ' + spec.body; }
+
+    if (window.umami) {
+      window.umami.track('tray_balloon_shown', { balloon_type: spec.type });
+    }
+
+    // Auto-dismiss after 10s (fixed per XP spec)
+    autoTimerId = setTimeout(function () {
+      dismissBalloon(balloon, 'auto');
+    }, t.TRAY_POPUP_DISPLAY_MS);
+
+    // Close button — delayed response per timing spec (Texture Zone click latency)
+    closeBtn.addEventListener('click', function () {
+      setTimeout(function () {
+        dismissBalloon(balloon, 'close');
+      }, t.rand(t.TRAY_CLICK_MIN_MS, t.TRAY_CLICK_MAX_MS));
+    });
+
+    // Body click — delayed response → action handler
+    bodyEl.addEventListener('click', function () {
+      setTimeout(function () {
+        dismissBalloon(balloon, 'body');
+        spec.onBodyClick();
+      }, t.rand(t.TRAY_CLICK_MIN_MS, t.TRAY_CLICK_MAX_MS));
+    });
+  }
+
+  function dismissBalloon(balloon, source) {
+    if (!balloon || !balloon.parentNode) { return; }
+    var t = window.APC.timing;
+
+    clearTimeout(autoTimerId);
+    autoTimerId = null;
+    clearTimeout(glitchTimerId);
+    glitchTimerId = null;
+
+    // body-click fires its own analytics event via the action handler
+    if (window.umami && source !== 'body') {
+      window.umami.track('tray_balloon_dismissed', { source: source });
+    }
+
+    // Exit transition: add --exit, then remove element after TRAY_BALLOON_EXIT_MS
+    balloon.classList.add('tray-balloon--exit');
+    setTimeout(function () {
+      if (balloon.parentNode) { balloon.parentNode.removeChild(balloon); }
+      if (currentBalloon === balloon) { currentBalloon = null; }
+      isBalloonVisible = false;
+      if (liveRegion) { liveRegion.textContent = ''; }
+    }, t.TRAY_BALLOON_EXIT_MS);
   }
 
   // --- Shared modal helper --------------------------------------------
@@ -319,11 +431,21 @@ window.APC.widgets = (function () {
     initTrayPopups();
   }
 
-  // Called by boot.restart() to cancel any in-flight popup timer so soft
-  // restarts don't accumulate parallel popup chains.
+  // Called by boot.restart() to cancel all in-flight timers and clear any
+  // live balloon so soft restarts don't accumulate parallel popup chains.
   function reset() {
     clearTimeout(trayPopupTimer);
     trayPopupTimer = null;
+    clearTimeout(autoTimerId);
+    autoTimerId = null;
+    clearTimeout(glitchTimerId);
+    glitchTimerId = null;
+    if (currentBalloon && currentBalloon.parentNode) {
+      currentBalloon.parentNode.removeChild(currentBalloon);
+      currentBalloon = null;
+    }
+    isBalloonVisible = false;
+    balloonTypeIndex = 0;
     if (liveRegion) { liveRegion.textContent = ''; }
   }
 

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -162,13 +162,20 @@
     RAM_RENDER_MIN_MS:          200, // delay between fetch and display update
     RAM_RENDER_MAX_MS:          400,
 
-    TRAY_POPUP_MIN_MS:        90000, // min interval between tray pop-up appearances
-    TRAY_POPUP_MAX_MS:       300000, // max interval
-    TRAY_POPUP_DISPLAY_MIN_MS: 4000, // how long each pop-up stays visible
-    TRAY_POPUP_DISPLAY_MAX_MS: 6000,
+    TRAY_POPUP_MIN_MS:           90000, // min interval between balloon appearances
+    TRAY_POPUP_MAX_MS:          300000, // max interval
+    TRAY_POPUP_DISPLAY_MS:       10000, // balloon visible duration (XP spec: ~10s)
 
-    TRAY_CLICK_MIN_MS:          100, // response delay on tray icon click
-    TRAY_CLICK_MAX_MS:          200,
+    TRAY_CLICK_MIN_MS:             100, // response delay on balloon body/icon click
+    TRAY_CLICK_MAX_MS:             200,
+
+    TRAY_BALLOON_ENTRY_MS:         150, // CSS transition: translateY + opacity in
+    TRAY_BALLOON_EXIT_MS:          100, // CSS transition: opacity out
+    TRAY_BALLOON_GLITCH_CHANCE:   1/20, // probability balloon renders behind taskbar
+    TRAY_BALLOON_GLITCH_MIN_MS:    400, // how long glitch persists before self-correcting
+    TRAY_BALLOON_GLITCH_MAX_MS:    600,
+    TRAY_BALLOON_Z_INDEX:         4000, // normal balloon z-index (above taskbar at 999)
+    TRAY_BALLOON_GLITCH_Z_INDEX:   998, // glitch z-index (below taskbar)
 
     // -------------------------------------------------------------------------
     // System Properties Dialog  —  TEXTURE ZONE


### PR DESCRIPTION
## Summary

- **win98-timing.js**: Fixes `TRAY_POPUP_DISPLAY_MS` to 10000ms per XP spec (was 4000–6000ms range); adds 7 new tokens for balloon animation (`TRAY_BALLOON_ENTRY_MS`, `TRAY_BALLOON_EXIT_MS`), glitch behavior (`TRAY_BALLOON_GLITCH_CHANCE`, `TRAY_BALLOON_GLITCH_MIN/MAX_MS`), and z-index values (`TRAY_BALLOON_Z_INDEX: 4000`, `TRAY_BALLOON_GLITCH_Z_INDEX: 998`)
- **widgets.js**: Full rewrite of tray popup system — two balloon types (Low Disk Space ⚠️ and Security Risk 🛡️) alternating in sequence (never random), `isBalloonVisible` + `protectedPathActive` suppression, behind-taskbar glitch (1-in-20, self-corrects after 400–600ms), CSS transition via double-rAF, 3 Umami analytics events (`tray_balloon_shown`, `tray_balloon_dismissed`, `tray_balloon_action`), Disk Cleanup body-click path stubbed with exact TODO per spec 24c49bfe; `reset()` cleans up all timers and live balloon on soft restart
- **win98.css**: `.tray-balloon` XP chrome — `#FFFFCC` background, gradient blue header (`#0A246A → #A6CAF0`), CSS triangle tail pseudo-elements, entry transition (150ms translateY+opacity), exit transition (100ms opacity), `border-radius: 6px` (intentional exception: XP chrome, not Win98 chrome)

## QA notes

- Balloons appear after 90–300s idle (Texture Zone — won't fire immediately in testing, reduce `TRAY_POPUP_MIN_MS` temporarily in devtools if needed)
- Confirm Low Disk Space and Security Risk alternate (not random)
- Confirm Security Risk body click opens Security Center modal
- Confirm Low Disk Space body click does nothing (stub — no modal, no crash)
- Confirm balloon doesn't appear during NetEscape page loads (`protectedPathActive`)
- Glitch is 5% chance — may need several balloon appearances to observe
- `reset()` tested via soft restart (Shut Down → Restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)