### PR TITLE
Fix: 50ms floor on pageLoadMidTimer (#59)

### DIFF
--- a/js/netescape.js
+++ b/js/netescape.js
@@ -447,9 +447,11 @@ window.APC.netescape = (function () {
     if (statusEl) { statusEl.textContent = ''; }
     if (statusEl) { statusEl.textContent = 'Opening page ' + url + '...'; }
 
+    // 50ms floor ensures "Transferring data..." is perceivable even when delay
+    // underflows to 0ms; without it, both timers fire on the same tick (#59).
     pageLoadMidTimer = setTimeout(function () {
       if (statusEl) { statusEl.textContent = 'Transferring data from ' + url + '...'; }
-    }, Math.floor(capped / 2));
+    }, Math.max(50, Math.floor(capped / 2)));
 
     pageLoadTimer = setTimeout(function () {
       pageLoadTimer = null;


### PR DESCRIPTION
## Summary

- `Math.floor(capped / 2)` could evaluate to `0` when the page load delay underflows, causing `pageLoadMidTimer` and `pageLoadTimer` to fire on the same tick — making the `"Transferring data from..."` status change imperceptible
- Added `Math.max(50, Math.floor(capped / 2))` to guarantee at least 50ms between the two status transitions

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)