### PR TITLE
fix: progress bar fills left-to-right on WinDoors logo screen

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -877,6 +877,7 @@ window.APC.boot = (function () {
       'background:#C0C0C0;',
       'border:1px solid #808080;',
       'font-size:0;line-height:0;',
+      'text-align:left;',
       'margin:0 auto;',
       'overflow:hidden;'
     ].join('');


### PR DESCRIPTION
## Summary

- Adds `text-align:left` to the WinDoors logo progress bar trough element
- The trough inherited center alignment from its parent `center` div, causing `inline-block` blocks to stack outward from the center instead of left to right
- One-line fix; no timing or layout changes

## Test plan

- [ ] Boot through the full sequence to Screen 4 (WinDoors logo)
- [ ] Confirm progress bar blocks fill from left edge, not from center outward

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)