### PR TITLE
fix: RAM counter too fast and linear — mechanical hesitation rhythm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,7 +304,7 @@ The boot sequence is a **six-state state machine** that fires after the gate cli
 
 **Screech roll:** Rolled once at gate interact. `screechFires = Math.random() < 0.6`. If fires: `screechScreen = Math.random() < 0.5 ? 'dos_log' : 'windoors_logo'`. Stored at module level, checked by Screens 3 and 4.
 
-**Screen 1 — POST (`renderPostScreen`):** Black background, white monospace. BIOS header lines print at `POST_TEXT_LINE_INTERVAL_MS` (100ms) intervals. RAM counter animates 0K → 131072K at `RAM_INCREMENT_INTERVAL_MS` (20ms) ticks. Post-beep plays after last line. `hddChatter.play()` called directly (no spinup).
+**Screen 1 — POST (`renderPostScreen`):** Black background, white monospace. BIOS header lines print at `POST_TEXT_LINE_INTERVAL_MS` (100ms) intervals. RAM counter animates 0K → 131072K in `RAM_STEP_K` (2048K) steps via recursive `setTimeout` at `RAM_TICK_MIN/MAX_MS` (30–90ms) per step; each step rolls `RAM_HESITATION_CHANCE` (8%) to insert a `RAM_HESITATION_MIN/MAX_MS` (200–600ms) mechanical pause before the next tick, simulating the machine verifying each memory block. Post-beep plays after last line. `hddChatter.play()` called directly (no spinup).
 
 **Screen 2 — IBS Splash (`renderIBSSplashScreen`):** Navy `#102046` background. CSS "IBS" logotype. Duration: `IBS_SPLASH_DURATION_MS` (6000ms). Floppy-seek plays at `FLOPPY_SEEK_DELAY_MIN/MAX_MS` (800–1000ms) after screen appears.
 

--- a/js/boot.js
+++ b/js/boot.js
@@ -633,9 +633,6 @@ window.APC.boot = (function () {
     function startRAMCounter() {
       if (gen !== bootGen) { return; }
       const RAM_TARGET = 131072;
-      // Derive step count from POST_DURATION_MS so counter fills in that window.
-      const totalSteps = Math.ceil(bs.POST_DURATION_MS / bs.RAM_INCREMENT_INTERVAL_MS);
-      const increment = Math.ceil(RAM_TARGET / totalSteps);
       let ramVal = 0;
 
       // Memory Test line with an inline span for the counter value.
@@ -646,16 +643,30 @@ window.APC.boot = (function () {
       ramDiv.appendChild(ramCounter);
       output.appendChild(ramDiv);
 
-      const timer = setInterval(function () {
-        if (gen !== bootGen) { clearInterval(timer); return; }
-        ramVal = Math.min(ramVal + increment, RAM_TARGET);
-        const formatted = String(ramVal) + 'K';
-        ramCounter.textContent = formatted.padStart(8, ' ');
+      // Recursive setTimeout with variable tick speed and occasional mechanical
+      // hesitation — simulates a real BIOS pausing to test each memory block
+      // rather than counting at a robotically fixed rate.
+      function tick() {
+        if (gen !== bootGen) { return; }
+        ramVal = Math.min(ramVal + bs.RAM_STEP_K, RAM_TARGET);
+        ramCounter.textContent = (String(ramVal) + 'K').padStart(8, ' ');
         if (ramVal >= RAM_TARGET) {
-          clearInterval(timer);
           onRAMComplete();
+          return;
         }
-      }, bs.RAM_INCREMENT_INTERVAL_MS);
+        const nextTick = t.rand(bs.RAM_TICK_MIN_MS, bs.RAM_TICK_MAX_MS);
+        if (Math.random() < bs.RAM_HESITATION_CHANCE) {
+          // Hesitation: counter stalls as if the machine is verifying that block.
+          setTimeout(function () {
+            if (gen !== bootGen) { return; }
+            setTimeout(tick, nextTick);
+          }, t.rand(bs.RAM_HESITATION_MIN_MS, bs.RAM_HESITATION_MAX_MS));
+        } else {
+          setTimeout(tick, nextTick);
+        }
+      }
+
+      setTimeout(tick, t.rand(bs.RAM_TICK_MIN_MS, bs.RAM_TICK_MAX_MS));
     }
 
     function onRAMComplete() {

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -209,10 +209,14 @@
     // -------------------------------------------------------------------------
 
     BOOT_SEQUENCE: {
-      POST_DURATION_MS:               4000, // RAM counter target duration
       POST_TEXT_LINE_INTERVAL_MS:      100, // ms between each header/footer line
       POST_AFTER_LAST_LINE_MS:         400, // pause after "Press DEL" before advance
-      RAM_INCREMENT_INTERVAL_MS:        20, // setInterval tick for RAM counter
+      RAM_TICK_MIN_MS:                  30, // fastest tick between RAM counter steps
+      RAM_TICK_MAX_MS:                  90, // slowest tick
+      RAM_HESITATION_CHANCE:          0.08, // ~1-in-12 chance of mechanical pause per step
+      RAM_HESITATION_MIN_MS:           200, // min hesitation duration
+      RAM_HESITATION_MAX_MS:           600, // max hesitation duration
+      RAM_STEP_K:                     2048, // KB increment per step (131072K / 64 steps)
 
       IBS_SPLASH_DURATION_MS:         6000, // total time on IBS BIOS splash screen
       FLOPPY_SEEK_DELAY_MIN_MS:        800, // floppy-seek fires this long after screen appears


### PR DESCRIPTION
## Summary

The POST screen RAM counter was a `setInterval` at a fixed 20ms tick, incrementing by a computed linear step — robotically uniform and too fast to read.

This replaces it with a recursive `setTimeout` with per-step rhythm variation and occasional mechanical hesitation pauses.

**Behavior change:**

| | Before | After |
|---|---|---|
| Tick mechanism | `setInterval` fixed 20ms | recursive `setTimeout` 30–90ms random |
| Step size | computed linear (~656K/tick) | fixed 2048K/step (64 steps total) |
| Hesitation | none | ~1-in-12 steps pause 200–600ms |
| Total duration | fixed ~4s | organic ~6–8s |

The hesitation roll fires after each step updates the counter display — the new value appears, then the machine "stalls" as if verifying that block of memory before advancing. Roughly 5–6 hesitations per run on average.

**`win98-timing.js` changes — `BOOT_SEQUENCE` object:**

Removed:
- `POST_DURATION_MS` (was used only to derive step count; no longer needed)
- `RAM_INCREMENT_INTERVAL_MS` (replaced by tick min/max)

Added:
- `RAM_TICK_MIN_MS: 30`
- `RAM_TICK_MAX_MS: 90`
- `RAM_HESITATION_CHANCE: 0.08`
- `RAM_HESITATION_MIN_MS: 200`
- `RAM_HESITATION_MAX_MS: 600`
- `RAM_STEP_K: 2048`

`CLAUDE.md` updated to reflect the new mechanism and tokens.

## Test plan

- [ ] Boot to POST screen — RAM counter reads 0K → 131072K at a visibly variable pace
- [ ] At least one hesitation pause is observable per boot (average ~5–6)
- [ ] Counter always reaches exactly 131072K before post-beep fires
- [ ] Generation guard (`if (gen !== bootGen) { return; }`) prevents stale ticks after gate restart
- [ ] Soft restart via Shut Down → Restart replays POST correctly with fresh counter

Closes #98.