### PR TITLE
feat: wormhole transition — Matrix rain spirals into desk scene (#106)

### DIFF
--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -133,7 +133,7 @@ boot.js was fully rewritten in PR #97. The old single-screen Win98 progress bar 
 - Phase 1 `WORMHOLE_DISTURBANCE_MS` (1500ms): characters drift tangentially (±30px), angle updated each frame for smooth Phase 2 handoff
 - Phase 2 `WORMHOLE_SPIRAL_MS` (2000ms): radius = `initRadius * (1 − easedT)²` — deterministic, characters arrive at center exactly at phase end; rotation speed increases with `easedT`; glow 0 → 120px
 - Phase 3 `WORMHOLE_COLLAPSE_MS` (500ms): glow pulse — hold 120px (first 40%), contract to 20px (last 60%)
-- Phase 4 `WORMHOLE_REVEAL_MS` (1000ms): desk scene bitmap revealed via `ctx.arc` + `clip()` from pinhole outward; cubic ease; glow fades
+- Phase 4 `WORMHOLE_REVEAL_MS` (2000ms): desk scene bitmap revealed via `ctx.arc` + `clip()` from pinhole outward; cubic ease; glow fades
 - On complete: `boot-scene.js` snaps sceneCanvas to `opacity:1` (no transition) and starts its rAF loop
 
 **Boot audio files** (all preloaded on gate interact, never before):

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -127,6 +127,15 @@ boot.js was fully rewritten in PR #97. The old single-screen Win98 progress bar 
 - `desktop.init()` called during the fade — desktop is visible behind it
 - `startup.mp3` fires at COMPLETE. `sessionStorage.boot_complete = '1'` set at COMPLETE.
 
+**Wormhole transition** (gate keypress → desk scene, #106) — fires before POST, ~5s total
+- `window.APC.boot.startWormhole(bitmap, bitmapParams, onComplete)` — public API on boot.js
+- Cancels matrix rain rAF, takes over `#matrix-canvas` for all four phases
+- Phase 1 `WORMHOLE_DISTURBANCE_MS` (1500ms): characters drift tangentially (±30px), angle updated each frame for smooth Phase 2 handoff
+- Phase 2 `WORMHOLE_SPIRAL_MS` (2000ms): radius = `initRadius * (1 − easedT)²` — deterministic, characters arrive at center exactly at phase end; rotation speed increases with `easedT`; glow 0 → 120px
+- Phase 3 `WORMHOLE_COLLAPSE_MS` (500ms): glow pulse — hold 120px (first 40%), contract to 20px (last 60%)
+- Phase 4 `WORMHOLE_REVEAL_MS` (1000ms): desk scene bitmap revealed via `ctx.arc` + `clip()` from pinhole outward; cubic ease; glow fades
+- On complete: `boot-scene.js` snaps sceneCanvas to `opacity:1` (no transition) and starts its rAF loop
+
 **Boot audio files** (all preloaded on gate interact, never before):
 - `hdd-chatter.mp3` — Screen 1 entry, fades on Screen 5
 - `post-beep.mp3` — RAM counter completion

--- a/js/boot-scene.js
+++ b/js/boot-scene.js
@@ -439,23 +439,25 @@ var POWER_X1  = 882, POWER_Y1  = 723, POWER_X2  = 927, POWER_Y2  = 738;
     });
     img.addEventListener('load', function () {
       processAsset(img, function () {
-        // Start the rAF loop and fade in the scene.
-        drawFrame();
-
-        // Fade in over BOOT_SCENE_FADE_IN_MS.
-        var t = window.APC.timing;
-        sceneCanvas.style.transition = 'opacity ' + t.BOOT_SCENE_FADE_IN_MS + 'ms ease';
-        // Double-rAF to ensure the initial opacity:0 has been painted before transition starts.
-        requestAnimationFrame(function () {
-          requestAnimationFrame(function () {
-            if (sceneCanvas) { sceneCanvas.style.opacity = '1'; }
-          });
+        // Wormhole transition (#106): matrix rain spirals into desk scene.
+        // startWormhole takes control of #matrix-canvas, runs four phases,
+        // then calls onComplete when the desk scene is fully revealed.
+        window.APC.boot.startWormhole(processedBitmap, {
+          offsetX: offsetX,
+          offsetY: offsetY,
+          scale:   scale,
+          assetW:  ASSET_W,
+          assetH:  ASSET_H
+        }, function () {
+          // Wormhole complete — snap scene canvas visible and start rAF.
+          if (!sceneCanvas) { return; }
+          sceneCanvas.style.transition = 'none';
+          sceneCanvas.style.opacity    = '1';
+          drawFrame();
+          sceneCanvas.addEventListener('mousemove', onMouseMove);
+          sceneCanvas.addEventListener('click', onCanvasClick);
+          window.addEventListener('resize', onResize);
         });
-
-        // Attach interaction listeners.
-        sceneCanvas.addEventListener('mousemove', onMouseMove);
-        sceneCanvas.addEventListener('click', onCanvasClick);
-        window.addEventListener('resize', onResize);
       });
     });
     img.src = 'assets/images/desk-scene_edited.png';

--- a/js/boot-scene.js
+++ b/js/boot-scene.js
@@ -25,10 +25,10 @@ var ASSET_W = 1024;
 var ASSET_H = 1172;
   
 var SCREEN_X1 = 201, SCREEN_Y1 = 205, SCREEN_X2 = 654, SCREEN_Y2 = 600;
-var POWER_X1  = 882, POWER_Y1  = 723, POWER_X2  = 927, POWER_Y2  = 738;
+var POWER_X1  = 875, POWER_Y1  = 715, POWER_X2  = 930, POWER_Y2  = 775;
 
   // Power indicator light (adjacent to power button in asset coordinates).
-  var INDICATOR_AX = 873, INDICATOR_AY = 680;
+  var INDICATOR_AX = 875, INDICATOR_AY = 710;
   var INDICATOR_SIZE_PX = 4; // unscaled size
 
   // Chroma key colors (exact — no tolerance).

--- a/js/boot-scene.js
+++ b/js/boot-scene.js
@@ -413,7 +413,8 @@ var POWER_X1  = 882, POWER_Y1  = 723, POWER_X2  = 927, POWER_Y2  = 738;
       'z-index:100;',
       'opacity:0;',
       'display:block;',
-      'background:transparent;'
+      'background:transparent;',
+      'pointer-events:none;'
     ].join('');
     document.body.appendChild(sceneCanvas);
     sceneCtx = sceneCanvas.getContext('2d');
@@ -451,8 +452,9 @@ var POWER_X1  = 882, POWER_Y1  = 723, POWER_X2  = 927, POWER_Y2  = 738;
         }, function () {
           // Wormhole complete — snap scene canvas visible and start rAF.
           if (!sceneCanvas) { return; }
-          sceneCanvas.style.transition = 'none';
-          sceneCanvas.style.opacity    = '1';
+          sceneCanvas.style.transition    = 'none';
+          sceneCanvas.style.opacity       = '1';
+          sceneCanvas.style.pointerEvents = '';
           drawFrame();
           sceneCanvas.addEventListener('mousemove', onMouseMove);
           sceneCanvas.addEventListener('click', onCanvasClick);

--- a/js/boot.js
+++ b/js/boot.js
@@ -1221,6 +1221,13 @@ window.APC.boot = (function () {
       animFrame = null;
     }
 
+    // Hide the gate prompt so it doesn't float over the wormhole animation.
+    var gatePrompt = document.getElementById('gate-prompt');
+    if (gatePrompt) {
+      gatePrompt.style.opacity    = '0';
+      gatePrompt.style.transition = 'none';
+    }
+
     var w  = canvas.width;
     var h  = canvas.height;
     var cx = w / 2;

--- a/js/boot.js
+++ b/js/boot.js
@@ -1198,6 +1198,215 @@ window.APC.boot = (function () {
     document.body.appendChild(overlay);
   }
 
-  return { init: init, restart: restart, shutdown: shutdown };
+  // --- Wormhole transition (#106) --------------------------------------
+  //
+  // Takes control of the Matrix rain canvas and runs a four-phase animation:
+  //   Phase 1 (0–1.5s)  — characters drift laterally (disturbance)
+  //   Phase 2 (1.5–3.5s) — characters spiral inward toward center
+  //   Phase 3 (3.5–4.0s) — glow pulse (expand then contract)
+  //   Phase 4 (4.0–5.0s) — desk scene revealed via circular clip
+  //
+  // bitmap     — processedBitmap from boot-scene.js (chroma-keyed desk PNG)
+  // bitmapParams — { offsetX, offsetY, scale, assetW, assetH }
+  // onComplete — fired when Phase 4 finishes (desk scene fully revealed)
+  //
+  // All timing from window.APC.timing — no hardcoded values.
+
+  function startWormhole(bitmap, bitmapParams, onComplete) {
+    var t = window.APC.timing;
+
+    // Cancel the matrix rain rAF — wormhole takes over the canvas.
+    if (animFrame) {
+      cancelAnimationFrame(animFrame);
+      animFrame = null;
+    }
+
+    var w  = canvas.width;
+    var h  = canvas.height;
+    var cx = w / 2;
+    var cy = h / 2;
+
+    var bmpOffX  = bitmapParams.offsetX;
+    var bmpOffY  = bitmapParams.offsetY;
+    var bmpScale = bitmapParams.scale;
+    var bmpW     = bitmapParams.assetW;
+    var bmpH     = bitmapParams.assetH;
+
+    var DIST_MS      = t.WORMHOLE_DISTURBANCE_MS;
+    var SPIRAL_MS    = t.WORMHOLE_SPIRAL_MS;
+    var COLLAPSE_MS  = t.WORMHOLE_COLLAPSE_MS;
+    var REVEAL_MS    = t.WORMHOLE_REVEAL_MS;
+    var GLOW_MAX_R   = t.WORMHOLE_GLOW_MAX_RADIUS;
+    var GLOW_PULSE_R = t.WORMHOLE_GLOW_PULSE_RADIUS;
+
+    // --- Build wormhole character grid ---
+    // One character per canvas cell at ~60% density, sampled from the full grid.
+    // Density keeps frame cost reasonable on large viewports.
+    var gridCols = Math.floor(w / FONT_SIZE);
+    var gridRows = Math.floor(h / FONT_SIZE);
+    var wormChars = [];
+
+    for (var ci = 0; ci < gridCols; ci++) {
+      for (var ri = 0; ri < gridRows; ri++) {
+        if (Math.random() > 0.6) { continue; }
+        var px  = ci * FONT_SIZE + FONT_SIZE / 2;
+        var py  = (ri + 1) * FONT_SIZE;
+        var dx  = px - cx;
+        var dy  = py - cy;
+        var dist = Math.sqrt(dx * dx + dy * dy);
+        wormChars.push({
+          origX:      px,
+          origY:      py,
+          initRadius: dist || 1,       // avoid 0-division at exact center
+          angle:      Math.atan2(dy, dx),
+          driftDir:   Math.random() > 0.5 ? 1 : -1,
+          char:       MATRIX_CHARS[Math.floor(Math.random() * MATRIX_CHARS.length)]
+        });
+      }
+    }
+
+    var startTime = null;
+    var prevTime  = null;
+    var wormRafId = null;
+
+    function drawGlow(glowRadius) {
+      if (glowRadius <= 0) { return; }
+      var grd = ctx.createRadialGradient(cx, cy, 0, cx, cy, glowRadius);
+      grd.addColorStop(0,   'rgba(0,255,65,0.9)');
+      grd.addColorStop(0.4, 'rgba(0,255,65,0.4)');
+      grd.addColorStop(1,   'rgba(0,255,65,0)');
+      ctx.globalAlpha = 1;
+      ctx.fillStyle   = grd;
+      ctx.fillRect(cx - glowRadius, cy - glowRadius, glowRadius * 2, glowRadius * 2);
+    }
+
+    function wormFrame(now) {
+      if (startTime === null) { startTime = now; prevTime = now; }
+      var elapsed   = now - startTime;
+      var deltaTime = now - prevTime;
+      prevTime = now;
+
+      // Black canvas base.
+      ctx.globalAlpha = 1;
+      ctx.fillStyle   = '#000';
+      ctx.fillRect(0, 0, w, h);
+
+      ctx.font      = FONT_SIZE + 'px "Courier New", monospace';
+      ctx.fillStyle = MATRIX_COLOR;
+
+      var i, c, glowRadius;
+
+      // --- Phase 1: Disturbance (0 → DIST_MS) ---
+      if (elapsed < DIST_MS) {
+        var prog     = elapsed / DIST_MS;
+        var maxDrift = 30; // px — matches spec
+
+        for (i = 0; i < wormChars.length; i++) {
+          c = wormChars[i];
+          // Drift perpendicular to radial direction (tangential).
+          var perpX = -Math.sin(c.angle);
+          var perpY =  Math.cos(c.angle);
+          var drift = prog * maxDrift * c.driftDir;
+          var dpx   = c.origX + perpX * drift;
+          var dpy   = c.origY + perpY * drift;
+
+          // Keep angle updated so Phase 2 starts from drifted position.
+          var ddx = dpx - cx;
+          var ddy = dpy - cy;
+          if (ddx !== 0 || ddy !== 0) { c.angle = Math.atan2(ddy, ddx); }
+
+          ctx.globalAlpha = 1;
+          ctx.fillText(c.char, dpx, dpy);
+        }
+
+      // --- Phase 2: Spiral (DIST_MS → DIST_MS + SPIRAL_MS) ---
+      } else if (elapsed < DIST_MS + SPIRAL_MS) {
+        var phaseElapsed = elapsed - DIST_MS;
+        var tNorm        = phaseElapsed / SPIRAL_MS;
+        var easedT       = tNorm * tNorm; // ease-in: slow start, fast finish
+
+        // Angular velocity increases as radius tightens.
+        var rotIncrement = 0.003 * (1 + easedT * 3) * deltaTime;
+
+        // Glow grows 0 → GLOW_MAX using smoothstep.
+        var glowProg = tNorm * tNorm * (3 - 2 * tNorm);
+        glowRadius   = glowProg * GLOW_MAX_R * bmpScale;
+
+        for (i = 0; i < wormChars.length; i++) {
+          c = wormChars[i];
+          // Radius formula: initRadius → 0 as easedT → 1 (position-based, no per-frame decay).
+          var newRadius = c.initRadius * Math.pow(1 - easedT, 2);
+          c.angle      += rotIncrement;
+          var spx       = cx + Math.cos(c.angle) * newRadius;
+          var spy       = cy + Math.sin(c.angle) * newRadius;
+
+          // Fade over last 40% of travel distance.
+          var fadeStart = c.initRadius * 0.4;
+          var opacity   = newRadius < fadeStart ? (newRadius / fadeStart) : 1;
+
+          ctx.globalAlpha = Math.max(0, opacity);
+          ctx.fillText(c.char, spx, spy);
+        }
+
+        drawGlow(glowRadius);
+
+      // --- Phase 3: Collapse (DIST_MS + SPIRAL_MS → … + COLLAPSE_MS) ---
+      } else if (elapsed < DIST_MS + SPIRAL_MS + COLLAPSE_MS) {
+        var phaseElapsed = elapsed - DIST_MS - SPIRAL_MS;
+        var prog         = phaseElapsed / COLLAPSE_MS;
+
+        // Characters all converged to center in Phase 2 — Phase 3 is pure glow pulse.
+        // First 40% (200ms): hold at GLOW_MAX. Next 60% (300ms): contract to GLOW_PULSE.
+        var EXPAND_FRAC = 0.4;
+        if (prog < EXPAND_FRAC) {
+          glowRadius = GLOW_MAX_R * bmpScale;
+        } else {
+          var contractProg = (prog - EXPAND_FRAC) / (1 - EXPAND_FRAC);
+          glowRadius = (GLOW_MAX_R - (GLOW_MAX_R - GLOW_PULSE_R) * contractProg) * bmpScale;
+        }
+
+        drawGlow(glowRadius);
+
+      // --- Phase 4: Reveal (… + COLLAPSE_MS → … + REVEAL_MS) ---
+      } else {
+        var phaseElapsed = elapsed - DIST_MS - SPIRAL_MS - COLLAPSE_MS;
+
+        if (phaseElapsed >= REVEAL_MS) {
+          // Fully revealed — draw complete bitmap then hand off.
+          ctx.globalAlpha = 1;
+          ctx.drawImage(bitmap, bmpOffX, bmpOffY, bmpW * bmpScale, bmpH * bmpScale);
+          cancelAnimationFrame(wormRafId);
+          if (onComplete) { onComplete(); }
+          return;
+        }
+
+        // Held glow fades as desk scene reveals.
+        glowRadius = GLOW_PULSE_R * bmpScale * (1 - phaseElapsed / REVEAL_MS);
+        drawGlow(glowRadius);
+
+        // Radial clip reveal: slow start, fast finish (cubic ease).
+        var tNorm  = phaseElapsed / REVEAL_MS;
+        var easedT = tNorm < 0.5
+          ? 2 * tNorm * tNorm
+          : -1 + (4 - 2 * tNorm) * tNorm;
+        var revealRadius = easedT * Math.max(w, h);
+
+        ctx.globalAlpha = 1;
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(cx, cy, revealRadius, 0, Math.PI * 2);
+        ctx.clip();
+        ctx.drawImage(bitmap, bmpOffX, bmpOffY, bmpW * bmpScale, bmpH * bmpScale);
+        ctx.restore();
+      }
+
+      ctx.globalAlpha = 1;
+      wormRafId = requestAnimationFrame(wormFrame);
+    }
+
+    wormRafId = requestAnimationFrame(wormFrame);
+  }
+
+  return { init: init, restart: restart, shutdown: shutdown, startWormhole: startWormhole };
 
 }());

--- a/js/boot.js
+++ b/js/boot.js
@@ -1239,18 +1239,21 @@ window.APC.boot = (function () {
     var GLOW_MAX_R   = t.WORMHOLE_GLOW_MAX_RADIUS;
     var GLOW_PULSE_R = t.WORMHOLE_GLOW_PULSE_RADIUS;
 
-    // --- Build wormhole character grid ---
-    // One character per canvas cell at ~60% density, sampled from the full grid.
-    // Density keeps frame cost reasonable on large viewports.
-    var gridCols = Math.floor(w / FONT_SIZE);
+    // --- Snapshot live Matrix rain columns ---
+    // Build wormChars from the actual columns array so the animation starts
+    // from the real rain state (column x-positions, current row as anchor).
+    // ~60% density keeps frame cost reasonable on large viewports.
     var gridRows = Math.floor(h / FONT_SIZE);
     var wormChars = [];
 
-    for (var ci = 0; ci < gridCols; ci++) {
+    for (var ci = 0; ci < columns.length; ci++) {
+      var col = columns[ci];
       for (var ri = 0; ri < gridRows; ri++) {
         if (Math.random() > 0.6) { continue; }
-        var px  = ci * FONT_SIZE + FONT_SIZE / 2;
-        var py  = (ri + 1) * FONT_SIZE;
+        var px  = col.x + FONT_SIZE / 2;
+        // Distribute rows relative to column's live rain-head position.
+        var row = (col.currentRow + ri) % gridRows;
+        var py  = (row + 1) * FONT_SIZE;
         var dx  = px - cx;
         var dy  = py - cy;
         var dist = Math.sqrt(dx * dx + dy * dy);
@@ -1330,7 +1333,7 @@ window.APC.boot = (function () {
 
         // Glow grows 0 → GLOW_MAX using smoothstep.
         var glowProg = tNorm * tNorm * (3 - 2 * tNorm);
-        glowRadius   = glowProg * GLOW_MAX_R * bmpScale;
+        glowRadius   = glowProg * GLOW_MAX_R;
 
         for (i = 0; i < wormChars.length; i++) {
           c = wormChars[i];
@@ -1359,10 +1362,10 @@ window.APC.boot = (function () {
         // First 40% (200ms): hold at GLOW_MAX. Next 60% (300ms): contract to GLOW_PULSE.
         var EXPAND_FRAC = 0.4;
         if (prog < EXPAND_FRAC) {
-          glowRadius = GLOW_MAX_R * bmpScale;
+          glowRadius = GLOW_MAX_R;
         } else {
           var contractProg = (prog - EXPAND_FRAC) / (1 - EXPAND_FRAC);
-          glowRadius = (GLOW_MAX_R - (GLOW_MAX_R - GLOW_PULSE_R) * contractProg) * bmpScale;
+          glowRadius = GLOW_MAX_R - (GLOW_MAX_R - GLOW_PULSE_R) * contractProg;
         }
 
         drawGlow(glowRadius);
@@ -1381,7 +1384,7 @@ window.APC.boot = (function () {
         }
 
         // Held glow fades as desk scene reveals.
-        glowRadius = GLOW_PULSE_R * bmpScale * (1 - phaseElapsed / REVEAL_MS);
+        glowRadius = GLOW_PULSE_R * (1 - phaseElapsed / REVEAL_MS);
         drawGlow(glowRadius);
 
         // Radial clip reveal: slow start, fast finish (cubic ease).

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -260,6 +260,18 @@
     CRT_IDLE_FLICKER_INTERVAL_MAX_MS: 12000, // max interval
     CRT_IDLE_FLICKER_DURATION_MS:        80, // how long the flicker dim lasts
 
+    // -------------------------------------------------------------------------
+    // Wormhole transition — Matrix rain → desk scene (#106)
+    // Fires on keypress at gate prompt. Four-phase, 5 seconds total.
+    // -------------------------------------------------------------------------
+
+    WORMHOLE_DISTURBANCE_MS:    1500,  // phase 1 — lateral drift before spiral
+    WORMHOLE_SPIRAL_MS:         2000,  // phase 2 — full inward vortex
+    WORMHOLE_COLLAPSE_MS:        500,  // phase 3 — final rush + glow pulse
+    WORMHOLE_REVEAL_MS:         1000,  // phase 4 — desk scene radial reveal
+    WORMHOLE_GLOW_MAX_RADIUS:    120,  // peak glow radius in px (pre-scale)
+    WORMHOLE_GLOW_PULSE_RADIUS:   20,  // contracted radius after collapse pulse
+
   };
 
 }());

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -268,7 +268,7 @@
     WORMHOLE_DISTURBANCE_MS:    1500,  // phase 1 — lateral drift before spiral
     WORMHOLE_SPIRAL_MS:         2000,  // phase 2 — full inward vortex
     WORMHOLE_COLLAPSE_MS:        500,  // phase 3 — final rush + glow pulse
-    WORMHOLE_REVEAL_MS:         1000,  // phase 4 — desk scene radial reveal
+    WORMHOLE_REVEAL_MS:         2000,  // phase 4 — desk scene radial reveal
     WORMHOLE_GLOW_MAX_RADIUS:    120,  // peak glow radius in px (pre-scale)
     WORMHOLE_GLOW_PULSE_RADIUS:   20,  // contracted radius after collapse pulse
 


### PR DESCRIPTION
## Summary
- Replaces the 600ms CSS fade-in with a 5-second four-phase wormhole portal
- `window.APC.boot.startWormhole(bitmap, bitmapParams, onComplete)` added to `boot.js` — cancels matrix rain rAF, takes full control of `#matrix-canvas`
- `boot-scene.js` defers rAF loop, listeners, and `opacity:1` snap until wormhole callback fires — no race conditions, no premature interaction

## Phase breakdown
| Phase | Duration | Effect |
|---|---|---|
| 1 — Disturbance | 1500ms | Characters drift ±30px tangentially; angle updated each frame for seamless handoff |
| 2 — Spiral | 2000ms | `radius = initRadius × (1−easedT)²` deterministic collapse; rotation speed grows with `easedT`; center glow 0→120px |
| 3 — Collapse | 500ms | Glow pulse: hold 120px (40%) → contract to 20px (60%) — the heartbeat moment |
| 4 — Reveal | 1000ms | `ctx.arc` + `clip()` radial reveal from pinhole; cubic ease; glow fades |

## Files changed
- `js/win98-timing.js` — 6 new tokens
- `js/boot.js` — `startWormhole` function + exported on public API
- `js/boot-scene.js` — `processAsset` callback replaced with `startWormhole` call
- `js/CLAUDE.md` — wormhole spec documented

## Test plan
- [ ] Keypress at gate prompt triggers wormhole (not instant fade-in)
- [ ] Phase 1: characters visibly drift sideways before spiraling
- [ ] Phase 2: characters spiral inward, center glow grows
- [ ] Phase 3: glow expands then contracts — visible pulse
- [ ] Phase 4: desk scene reveals from center pinhole outward, accelerating
- [ ] Total duration ~5 seconds from keypress to desk scene fully interactive
- [ ] Power button clickable after wormhole completes
- [ ] No console errors on Chrome and Firefox
- [ ] rAF tears down cleanly (no ghost loops after desk scene appears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)