### PR TITLE
fix: CRT sequence off-canvas + boot audio guard (#116)

### DIFF
--- a/js/boot-scene.js
+++ b/js/boot-scene.js
@@ -90,7 +90,7 @@ var POWER_X1  = 882, POWER_Y1  = 723, POWER_X2  = 927, POWER_Y2  = 738;
   // Called once on init and again on every resize.
 
   function computeRegions() {
-    scale = Math.max(window.innerWidth / ASSET_W, window.innerHeight / ASSET_H);
+    scale = Math.min(window.innerWidth / ASSET_W, window.innerHeight / ASSET_H);
     var drawW = ASSET_W * scale;
     var drawH = ASSET_H * scale;
     offsetX = (window.innerWidth  - drawW) / 2;

--- a/js/boot.js
+++ b/js/boot.js
@@ -497,6 +497,10 @@ window.APC.boot = (function () {
       window.APC.bootScene.init(function () {
         cancelAnimationFrame(animFrame);
         hideGate();
+        // Guard: preloadBootAudio() should have fired in onGateInteract, but if
+        // bootAudio is somehow null (e.g. soft restart race), preload it now so
+        // renderPostScreen() can always play hdd-chatter.
+        if (!bootAudio) { preloadBootAudio(); }
         advanceBootState(BOOT_STATE.POST);
       });
     }, window.APC.timing.GATE_FADE_MS);


### PR DESCRIPTION
## Root cause

`Math.max` in `computeRegions()` picks `widthScale` (≈1.875 on 1920×1080), scaling the 1172px-tall asset to 2197px — 559px overflowing above and below the viewport. Results:

| Region | With Math.max (broken) | With Math.min (fixed) |
|---|---|---|
| `screenRegion.y` | ≈ −174px (off canvas) | ≈ +189px (visible) |
| `powerRegion.y` | ≈ +797px (visible but CRT invisible) | ≈ +666px (correct) |
| `offsetY` | −559px | ≈ 0px |

`Math.min` letterboxes the image so it always fits within viewport height, with pillarbox padding on the sides. All regions land on screen at every common desktop resolution.

## Changes
- `js/boot-scene.js` — `Math.max` → `Math.min` in `computeRegions()` (one character)
- `js/boot.js` — `if (!bootAudio) { preloadBootAudio(); }` guard before `advanceBootState(POST)` in case a soft-restart race leaves `bootAudio` null

## Test plan
- [ ] Power button click shows full 5-step CRT sequence inside the monitor bezel
- [ ] Boot audio plays (hdd-chatter, post-beep, etc.) after CRT sequence completes
- [ ] Desk scene is fully visible and letterboxed (not clipped) at 1920×1080, 1440×900, 1280×800
- [ ] Power button hit region aligns with the physical button in the desk scene image
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)