### PR TITLE
fix: CRT sequence cancellation — addTimeout → setTimeout in startCRTSequence (#118)

### DIFF
--- a/js/boot-scene.js
+++ b/js/boot-scene.js
@@ -318,6 +318,11 @@ var POWER_X1  = 882, POWER_Y1  = 723, POWER_X2  = 927, POWER_Y2  = 738;
   //
   // Five steps driven by chained timeouts. The rAF loop reads crtState each frame.
   // All timing from window.APC.timing — no hardcoded values.
+  //
+  // IMPORTANT: all post-click timeouts use plain setTimeout, NOT addTimeout.
+  // addTimeout() tracks into pendingTimeouts which clearAllTimeouts() can cancel.
+  // Once the power button is clicked the CRT sequence must run to completion
+  // regardless of any other teardown path — it must not be cancellable.
 
   function startCRTSequence() {
     if (powerClicked) { return; }
@@ -332,32 +337,32 @@ var POWER_X1  = 882, POWER_Y1  = 723, POWER_X2  = 927, POWER_Y2  = 738;
     crtState = 'btn_flash';
 
     // Step 1: CRT white flash starts after button flash.
-    addTimeout(function () { crtState = 'flash'; }, t.POWER_BTN_FLASH_MS);
+    setTimeout(function () { crtState = 'flash'; }, t.POWER_BTN_FLASH_MS);
 
     // Step 2: dim.
-    addTimeout(function () { crtState = 'dim'; },
+    setTimeout(function () { crtState = 'dim'; },
       t.POWER_BTN_FLASH_MS + t.CRT_FLASH_MS);
 
     // Step 3: scanlines.
-    addTimeout(function () { crtState = 'scanlines'; },
+    setTimeout(function () { crtState = 'scanlines'; },
       t.POWER_BTN_FLASH_MS + t.CRT_FLASH_MS + t.CRT_DIM_MS);
 
     // Step 4: phosphor glow.
-    addTimeout(function () { crtState = 'glow'; },
+    setTimeout(function () { crtState = 'glow'; },
       t.POWER_BTN_FLASH_MS + t.CRT_FLASH_MS + t.CRT_DIM_MS + t.CRT_SCANLINE_MS);
 
     // Step 5: rain visible.
-    addTimeout(function () { crtState = 'rain_on'; },
+    setTimeout(function () { crtState = 'rain_on'; },
       t.POWER_BTN_FLASH_MS + t.CRT_FLASH_MS + t.CRT_DIM_MS +
       t.CRT_SCANLINE_MS + t.CRT_GLOW_MS);
 
     // After step 5 completes, fade out desk scene and hand off.
-    addTimeout(function () {
+    var totalCRTDuration = t.POWER_BTN_FLASH_MS + t.CRT_FLASH_MS + t.CRT_DIM_MS +
+                           t.CRT_SCANLINE_MS + t.CRT_GLOW_MS + t.CRT_CONTENT_FADE_MS;
+    setTimeout(function () {
       crtState = 'done';
       fadeOutAndComplete();
-    },
-      t.POWER_BTN_FLASH_MS + t.CRT_FLASH_MS + t.CRT_DIM_MS +
-      t.CRT_SCANLINE_MS + t.CRT_GLOW_MS + t.CRT_CONTENT_FADE_MS);
+    }, totalCRTDuration);
   }
 
   // --- Fade out and teardown --------------------------------------------------


### PR DESCRIPTION
## Root cause

All six CRT state-transition timeouts in `startCRTSequence()` were registered via `addTimeout()`, which pushes their IDs into `pendingTimeouts`. `clearAllTimeouts()` (called from `destroy()`) was cancelling them before they could fire — causing the sequence to skip steps 2–5 immediately after the white flash.

## Fix

Replace all six `addTimeout()` calls in `startCRTSequence()` with plain `setTimeout()`. Post-click CRT timeouts are terminal — once the power button is clicked they must run to completion regardless of any teardown path.

Pre-click timeouts (`flickerTimer`, idle flicker scheduling) correctly remain on `addTimeout()` so they can be cancelled if the user somehow triggers a reset before clicking.

Final timeout duration extracted to `totalCRTDuration` for readability.

## Test plan
- [ ] Power button click shows all 5 CRT steps: white flash → dark → scanlines → green glow → Matrix rain in screen
- [ ] Full CRT sequence takes ~1.1s before desk scene fades out
- [ ] Boot sequence (POST screen) starts after CRT completes
- [ ] Boot audio plays (hdd-chatter.mp3, post-beep.mp3 etc.)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)