### PR TITLE
fix+feat: zoom-into-monitor, fix CRT rain_on, fix fadeOutAndComplete (#124)

### DIFF
--- a/js/boot-scene.js
+++ b/js/boot-scene.js
@@ -333,6 +333,10 @@ var POWER_X1  = 875, POWER_Y1  = 715, POWER_X2  = 930, POWER_Y2  = 775;
     // Power indicator turns on immediately.
     powerOn = true;
 
+    // Refresh matrixCanvas reference — after the wormhole the rain rAF was
+    // restarted (PR #123), so the element is live and animating in the DOM.
+    matrixCanvas = document.getElementById('matrix-canvas');
+
     // Power button flash (visual response — CRT screen stays dark).
     crtState = 'btn_flash';
 
@@ -367,31 +371,59 @@ var POWER_X1  = 875, POWER_Y1  = 715, POWER_X2  = 930, POWER_Y2  = 775;
   }
 
   // --- Fade out and teardown --------------------------------------------------
+  //
+  // Two-phase exit (#124):
+  //   Phase 1 — zoom in toward monitor center over DESK_ZOOM_MS (3000ms)
+  //   Phase 2 — fade opacity 1→0 over BOOT_SCENE_FADE_OUT_MS (400ms)
+  //
+  // All plain setTimeout — must NOT be cancellable by clearAllTimeouts().
+  // Fix 2 (#124): clear any existing transition before setting the zoom
+  // transition so a lingering fade-in transition doesn't override it.
 
   function fadeOutAndComplete() {
-    var t = window.APC.timing;
-    sceneCanvas.style.transition = 'opacity ' + t.BOOT_SCENE_FADE_OUT_MS + 'ms ease';
-    sceneCanvas.style.opacity    = '0';
+    var t  = window.APC.timing;
+    var sr = screenRegion;
 
-    // Plain setTimeout — must NOT be cancellable by clearAllTimeouts().
-    // Once the CRT sequence commits to handoff, destroy() and onComplete()
-    // must always fire in the right order.
+    // Anchor the CSS transform origin to the center of the monitor screen region.
+    var cx = sr.x + sr.w / 2;
+    var cy = sr.y + sr.h / 2;
+    sceneCanvas.style.transformOrigin = cx + 'px ' + cy + 'px';
+
+    // Clear any lingering transition (e.g. from fade-in phase) so the zoom
+    // transition takes effect cleanly on the next frame.
+    sceneCanvas.style.transition = 'none';
+    void sceneCanvas.offsetHeight; // force reflow
+
+    // Phase 1: zoom in toward monitor center.
+    sceneCanvas.style.transition = 'transform ' + t.DESK_ZOOM_MS + 'ms ease-in';
+    requestAnimationFrame(function () {
+      requestAnimationFrame(function () {
+        sceneCanvas.style.transform = 'scale(' + t.DESK_ZOOM_SCALE + ')';
+      });
+    });
+
+    // Phase 2: after zoom, fade out then hand off.
     setTimeout(function () {
-      // Clear stale Matrix rain pixels so they don't bleed through boot screens.
-      var mc = document.getElementById('matrix-canvas');
-      if (mc) { mc.getContext('2d').clearRect(0, 0, mc.width, mc.height); }
+      sceneCanvas.style.transition = 'opacity ' + t.BOOT_SCENE_FADE_OUT_MS + 'ms ease';
+      sceneCanvas.style.opacity    = '0';
 
-      // Fully hide gate screen (inline opacity overrides any lingering CSS).
-      var gs = document.getElementById('gate-screen');
-      if (gs) {
-        gs.style.opacity    = '0';
-        gs.style.transition = 'none';
-        gs.classList.add('gate-screen--hidden');
-      }
+      setTimeout(function () {
+        // Clear stale Matrix rain pixels so they don't bleed through boot screens.
+        var mc = document.getElementById('matrix-canvas');
+        if (mc) { mc.getContext('2d').clearRect(0, 0, mc.width, mc.height); }
 
-      destroy();
-      if (onComplete) { onComplete(); }
-    }, t.BOOT_SCENE_FADE_OUT_MS);
+        // Fully hide gate screen (inline opacity overrides any lingering CSS).
+        var gs = document.getElementById('gate-screen');
+        if (gs) {
+          gs.style.opacity    = '0';
+          gs.style.transition = 'none';
+          gs.classList.add('gate-screen--hidden');
+        }
+
+        destroy();
+        if (onComplete) { onComplete(); }
+      }, t.BOOT_SCENE_FADE_OUT_MS);
+    }, t.DESK_ZOOM_MS);
   }
 
   // --- Public API -------------------------------------------------------------

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -246,7 +246,9 @@
     // -------------------------------------------------------------------------
 
     BOOT_SCENE_FADE_IN_MS:              600, // desk scene canvas fade-in duration
-    BOOT_SCENE_FADE_OUT_MS:             400, // desk scene canvas fade-out after CRT sequence
+    BOOT_SCENE_FADE_OUT_MS:             400, // desk scene canvas fade-out after zoom completes
+    DESK_ZOOM_MS:                      3000, // zoom-into-monitor animation duration (#124)
+    DESK_ZOOM_SCALE:                      8, // scale factor — monitor fills viewport at end
 
     CRT_FLASH_MS:                        80, // step 1: CRT screen white flash duration
     CRT_DIM_MS:                         120, // step 2: dims to #1A1A1A


### PR DESCRIPTION
Closes #124.

## Changes

### Fix 1 — `rain_on` CRT state shows black (matrixCanvas stale reference)
`matrixCanvas` was set once during `init()`. After the wormhole, PR #123 restarts the rain rAF but `matrixCanvas` still held its original reference — in practice the same DOM element, but a refresh at the top of `startCRTSequence()` makes the dependency explicit and guards against any future teardown path that might null it.

### Fix 2 — Fade-out transition suppressed by lingering fade-in transition
`sceneCanvas` had `transition: opacity 600ms ease` set from the wormhole callback's snap-to-visible. Setting a new transition without clearing it first left the old value racing. Fixed with `transition: none` + `void offsetHeight` (force reflow) before applying the zoom transition.

### Feature — Zoom-into-monitor before boot sequence (3 s)
`fadeOutAndComplete()` now runs two phases:
- **Phase 1** (`DESK_ZOOM_MS` = 3000ms, ease-in): CSS `transform: scale(8)` anchored to the center of `screenRegion` — the monitor fills and overflows the viewport
- **Phase 2** (`BOOT_SCENE_FADE_OUT_MS` = 400ms): opacity 1→0, then canvas clear + gate hide + `destroy()` + `onComplete()`

Both phases use plain `setTimeout` — not `addTimeout` — so they cannot be cancelled by `clearAllTimeouts()`.

**New tokens:** `DESK_ZOOM_MS: 3000`, `DESK_ZOOM_SCALE: 8`

## Test plan
- [ ] `[CRT] rain_on` — Matrix rain visible inside monitor bezel during step 5
- [ ] After CRT sequence: desk scene zooms toward monitor center over ~3s
- [ ] Monitor fills viewport at end of zoom
- [ ] Desk scene fades out over ~400ms after zoom
- [ ] POST screen appears cleanly (no rain bleed, no gate screen remnant)
- [ ] Full boot sequence + audio plays
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)