### PR TITLE
polish: extend CRT step durations + slow desk scene fade-out (#126)

### DIFF
--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -246,15 +246,15 @@
     // -------------------------------------------------------------------------
 
     BOOT_SCENE_FADE_IN_MS:              600, // desk scene canvas fade-in duration
-    BOOT_SCENE_FADE_OUT_MS:             400, // desk scene canvas fade-out after zoom completes
+    BOOT_SCENE_FADE_OUT_MS:            3000, // desk scene canvas fade-out after zoom completes
     DESK_ZOOM_MS:                      3000, // zoom-into-monitor animation duration (#124)
     DESK_ZOOM_SCALE:                      8, // scale factor — monitor fills viewport at end
 
     CRT_FLASH_MS:                        80, // step 1: CRT screen white flash duration
-    CRT_DIM_MS:                         120, // step 2: dims to #1A1A1A
-    CRT_SCANLINE_MS:                    200, // step 3: alternating scanline rows visible
-    CRT_GLOW_MS:                        300, // step 4: phosphor green glow fill
-    CRT_CONTENT_FADE_MS:                400, // step 5: matrix rain fades in at 0.6 opacity
+    CRT_DIM_MS:                        2120, // step 2: dims to #1A1A1A
+    CRT_SCANLINE_MS:                   2200, // step 3: alternating scanline rows visible
+    CRT_GLOW_MS:                       2300, // step 4: phosphor green glow fill
+    CRT_CONTENT_FADE_MS:               1400, // step 5: matrix rain fades in at 0.6 opacity
 
     POWER_BTN_FLASH_MS:                 100, // power button white flash on click
 


### PR DESCRIPTION
## Summary

- `CRT_DIM_MS`: 120ms → 2120ms (+2s)
- `CRT_SCANLINE_MS`: 200ms → 2200ms (+2s)
- `CRT_GLOW_MS`: 300ms → 2300ms (+2s)
- `CRT_CONTENT_FADE_MS`: 400ms → 1400ms (+1s)
- `BOOT_SCENE_FADE_OUT_MS`: 400ms → 3000ms (+2.6s)

Total CRT duration: ~8.1s (was ~1.1s). Desk scene exit: 3s zoom + 3s fade = ~6s before boot sequence.

Only `js/win98-timing.js` modified — all timing is sourced from tokens.

Closes #126.

## Test plan
- [ ] Power button → white flash → dim → scanlines → green glow → rain fade-in, each step visibly distinct
- [ ] Desk scene zoom completes before fade-out begins
- [ ] Boot POST screen appears after full fade-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)