### PR TITLE
fix: capture onComplete before destroy() so boot sequence fires (#128)

### DIFF
--- a/js/boot-scene.js
+++ b/js/boot-scene.js
@@ -420,8 +420,9 @@ var POWER_X1  = 875, POWER_Y1  = 715, POWER_X2  = 930, POWER_Y2  = 775;
           gs.classList.add('gate-screen--hidden');
         }
 
+        var cb = onComplete;
         destroy();
-        if (onComplete) { onComplete(); }
+        if (cb) { cb(); }
       }, t.BOOT_SCENE_FADE_OUT_MS);
     }, t.DESK_ZOOM_MS);
   }
@@ -467,8 +468,9 @@ var POWER_X1  = 875, POWER_Y1  = 715, POWER_X2  = 930, POWER_Y2  = 775;
     var img = new Image();
     img.addEventListener('error', function () {
       // Asset load failed — skip scene and go straight to boot.
+      var cb = onComplete;
       destroy();
-      if (onComplete) { onComplete(); }
+      if (cb) { cb(); }
     });
     img.addEventListener('load', function () {
       processAsset(img, function () {


### PR DESCRIPTION
## Summary

- `destroy()` nulls the module-level `onComplete` variable (line 536 of `boot-scene.js`)
- The original code called `destroy()` then `if (onComplete) { onComplete(); }` — `onComplete` was always `null` by then, so `advanceBootState(POST)` never fired
- Fix: capture `onComplete` into a local `cb` before calling `destroy()`, then call `cb()`
- Same fix applied to the `img.onerror` fallback path in `init()`

Only `js/boot-scene.js` modified. Two hunks, four lines changed.

Closes #128.

## Test plan
- [ ] Click gate prompt → wormhole plays → desk scene appears → click power button → CRT sequence runs → desk scene zooms and fades → POST screen appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)