### PR TITLE
feat: HDD audio — power button trigger + onComplete capture fix (boot-scene.js)

### DIFF
--- a/js/boot-scene.js
+++ b/js/boot-scene.js
@@ -333,6 +333,14 @@ var POWER_X1  = 875, POWER_Y1  = 715, POWER_X2  = 930, POWER_Y2  = 775;
     // Power indicator turns on immediately.
     powerOn = true;
 
+    // Start HDD audio: poweron.mp3 plays immediately, chatter.mp3 starts at crossfade
+    // offset (9950ms). Audio-before-visual — same as a real PC powering on.
+    // Guard: defensive check in case boot.js is not yet loaded or playHddAudio was
+    // not exposed on the public API.
+    if (window.APC.boot && typeof window.APC.boot.playHddAudio === 'function') {
+      window.APC.boot.playHddAudio();
+    }
+
     // Refresh matrixCanvas reference — after the wormhole the rain rAF was
     // restarted (PR #123), so the element is live and animating in the DOM.
     matrixCanvas = document.getElementById('matrix-canvas');


### PR DESCRIPTION
## Summary

Part 3 of 3 for the HDD audio redesign. Only `js/boot-scene.js` is changed.

**Change 1 (this PR):** `startCRTSequence()` — call `window.APC.boot.playHddAudio()` immediately after `powerOn = true`. `hdd-poweron.mp3` starts on click; `hdd-chatter.mp3` starts at the 9950ms crossfade offset (scheduled inside `playHddAudio()`). Guarded with a `typeof` check in case the public API isn't available.

**Changes 2 & 3 (already on main via #128/#129):** The `onComplete` capture fix (`var cb = onComplete` before `destroy()`) was implemented in PR #129. No further changes needed to `fadeOutAndComplete()` or `img.onerror`.

Closes #133. Depends on #131 (timing tokens) and #132 (boot.js).

## Test plan
- [ ] Click power button → `hdd-poweron.mp3` audible immediately (click + whirr)
- [ ] At ~9950ms: `hdd-chatter.mp3` joins — crossfade seam inaudible
- [ ] CRT sequence runs all 6 states → desk scene zooms + fades → POST appears
- [ ] Chatter runs continuously through POST → IBS Splash → DOS Log → WinDoors Logo → Desktop Arrival → COMPLETE
- [ ] WinDoors stalls: chatter dips to 0.7, restores to 1.0
- [ ] `startup.mp3` fires at COMPLETE; ~5s later chatter fades to 0.6
- [ ] Soft restart: audio stops, full sequence replays correctly on next power click
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)