### PR TITLE
feat: Matrix rain — randomized duration, per-column speed, natural emoji color, localStorage TTL

### DIFF
--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -88,6 +88,40 @@ Never call `sessionStorage.clear()`. Use targeted `removeItem()` only.
 
 ---
 
+## Matrix Rain (boot.js)
+
+The Matrix rain canvas runs inside `boot.js` under the `window.APC.boot` namespace. There is no separate `matrix.js`.
+
+**Session persistence — localStorage TTL:**
+- On boot completion: `localStorage.setItem('boot_complete_ts', Date.now())`
+- On page load (`init()`): if `boot_complete_ts` exists and is < 1 hour old (`MATRIX_SESSION_TTL_MS`), skip rain + boot, go straight to desktop
+- Bypass with `window.APC.boot.init({ force: true })` — used by `restart()` and taskbar `doRestart()`
+- Do NOT use `sessionStorage` for boot-skip logic. `sessionStorage.boot_complete` is removed.
+
+**Rain duration — randomized at init time:**
+- `rainDuration = rand(MATRIX_DURATION_MIN_MS, MATRIX_DURATION_MAX_MS)` (3–12s)
+- Chosen once in `init()`, stored in `rainDuration`, reset to 0 on `restart()`
+- `rainStartTime` set on first `drawFrame()` call
+- When `Date.now() - rainStartTime >= rainDuration`: cancel rAF, call `revealPrompt()`
+
+**Per-column fixed speed:**
+- Base velocity: 100ms per character step (documented in `initColumns()` comment)
+- Each column gets `speedFactor = rand(MATRIX_COL_SPEED_MIN_PCT, MATRIX_COL_SPEED_MAX_PCT)` (0.80–1.00)
+- `col.charDelay = Math.round(100 / speedFactor)` → range 100–125ms
+- charDelay is NOT re-rolled when a column resets to the top — speed is fixed for the full duration
+
+**Emoji rendering — natural color, no filter:**
+- Frequency: exactly `MATRIX_EMOJI_FREQUENCY` (2%) — fixed, not re-rolled per character
+- Emojis render in natural OS color. No CSS filter. Do not add a filter.
+- Do NOT use the old `ctx.filter = 'brightness(0) saturate(100%)...'` hack — it is removed
+- Emoji list is defined in `MATRIX_EMOJIS` const in boot.js
+
+**`init(options)` signature:**
+- `options.force = true` bypasses the localStorage TTL check
+- No argument (or `{}`) = normal path with TTL check
+
+---
+
 ## Boot Sequence State Machine (boot.js)
 
 boot.js was fully rewritten in PR #97. The old single-screen Win98 progress bar is gone — do not restore it.

--- a/js/boot.js
+++ b/js/boot.js
@@ -13,8 +13,7 @@ window.APC.boot = (function () {
 
   const MATRIX_COLOR = '#00FF41';
   const FONT_SIZE = 14;
-  const MATRIX_EMOJI_FREQUENCY_MIN = 0.01; // emoji appears in 1–5% of characters,
-  const MATRIX_EMOJI_FREQUENCY_MAX = 0.05; // re-rolled per draw call
+  // Emoji frequency is fixed at MATRIX_EMOJI_FREQUENCY (2%) — no per-draw re-roll.
 
   // Exact character set from CLAUDE.md spec — half-width katakana + ASCII + symbols.
   const MATRIX_CHARS = [
@@ -24,11 +23,12 @@ window.APC.boot = (function () {
     '@#$%*+-=:<>/\\|'
   ];
 
-  // Curated emoji set — interests and themes personal to Atsushi's PC.
+  // Curated emoji set — renders in natural OS color, no filter applied.
   const MATRIX_EMOJIS = [
-    '🎾', '⛳', '🎣', '🍜', '🍕', '🎮', '✈️', '🌍', '🌱',
-    '💾', '🖥️', '🔌', '🛠️', '🎭', '🧩', '🧠', '⚙️', '🔍',
-    '♟️', '🌉', '📦', '🧨', '📊', '🧭'
+    '💩', '👾', '👍', '🧳', '🛜', '♻️', '🌐', '❤️', '✏️', '🙈',
+    '🎉', '🎥', '📺', '🕹', '⛰', '🚲', '🛻', '🎳', '🎼', '🚴‍♂️',
+    '🏀', '🎾', '🎱', '🛹', '🏌️‍♂️', '🍺', '🧀', '🍕', '🥨', '🥦',
+    '🍓', '🍋', '⚡️', '🌧', '🌞', '🦖', '🌲'
   ];
 
   // --- Boot state enum (#89) -------------------------------------------
@@ -78,6 +78,11 @@ window.APC.boot = (function () {
 
   let canvas, ctx, columns, animFrame;
   let hasStarted = false;
+
+  // Rain duration — randomized once per init(), cleared on restart.
+  // Range: MATRIX_DURATION_MIN_MS–MATRIX_DURATION_MAX_MS (3–12s).
+  let rainDuration = 0;
+  let rainStartTime = null;
 
   // Identity lines state.
   let identityPhase = 'waiting'; // waiting | line1_instant | line1_hold | typing | pause | done
@@ -230,19 +235,32 @@ window.APC.boot = (function () {
 
   // --- Boot init -------------------------------------------------------
 
-  function init() {
+  function init(options) {
+    const force = options && options.force === true;
+
     // Hard gate: WinDoors 98 does not run on mobile or touch devices.
     if (isMobileOrTouch()) {
       showMobileInterstitial();
       return;
     }
 
-    // Skip gate and boot sequence if already completed this session.
-    if (sessionStorage.getItem('boot_complete')) {
-      hideGate();
-      goToDesktop(true);
-      return;
+    // localStorage TTL check — skip rain + boot if visited within the last hour.
+    // Bypass with { force: true } (Restart flow).
+    if (!force) {
+      const ts = localStorage.getItem('boot_complete_ts');
+      const elapsed = ts ? Date.now() - parseInt(ts, 10) : Infinity;
+      if (elapsed < window.APC.timing.MATRIX_SESSION_TTL_MS) {
+        hideGate();
+        goToDesktop(true);
+        return;
+      }
     }
+
+    // Roll rain duration once — stays fixed for this run.
+    const t = window.APC.timing;
+    rainDuration = t.MATRIX_DURATION_MIN_MS +
+      Math.random() * (t.MATRIX_DURATION_MAX_MS - t.MATRIX_DURATION_MIN_MS);
+    rainStartTime = null; // set on first drawFrame call
 
     canvas = document.getElementById('matrix-canvas');
     ctx = canvas.getContext('2d');
@@ -354,13 +372,19 @@ window.APC.boot = (function () {
     const t = window.APC.timing;
     const count = Math.floor(canvas.width / FONT_SIZE);
     const rows = Math.floor(canvas.height / FONT_SIZE);
+    // Base velocity: 100ms per character step — tuned for readability at 1080p desktop.
+    // Each column's charDelay = BASE_CHAR_DELAY_MS / speedFactor, giving a fixed
+    // 100–125ms range (MATRIX_COL_SPEED_MIN_PCT 0.80 → 125ms, MAX 1.00 → 100ms).
+    const BASE_CHAR_DELAY_MS = 100;
     columns = [];
     for (let i = 0; i < count; i++) {
+      const speedFactor = t.MATRIX_COL_SPEED_MIN_PCT +
+        Math.random() * (t.MATRIX_COL_SPEED_MAX_PCT - t.MATRIX_COL_SPEED_MIN_PCT);
       columns.push({
         x: i * FONT_SIZE,
         currentRow: Math.floor(Math.random() * rows),
         nextCharTime: Date.now() + Math.floor(Math.random() * t.MATRIX_RAIN_STAGGER_MAX_MS),
-        charDelay: t.rand(t.MATRIX_RAIN_CHAR_MIN_MS, t.MATRIX_RAIN_CHAR_MAX_MS),
+        charDelay: Math.round(BASE_CHAR_DELAY_MS / speedFactor), // fixed for duration — no re-roll
         pauseUntil: 0
       });
     }
@@ -373,9 +397,18 @@ window.APC.boot = (function () {
   // redrawn at full brightness each frame so the fade overlay doesn't dim them.
 
   function drawFrame() {
-    animFrame = requestAnimationFrame(drawFrame);
-
     const now = Date.now();
+
+    // Duration check — stop rain and reveal prompt when time is up.
+    if (rainStartTime === null) { rainStartTime = now; }
+    if (!hasStarted && (now - rainStartTime) >= rainDuration) {
+      cancelAnimationFrame(animFrame);
+      animFrame = null;
+      revealPrompt();
+      return;
+    }
+
+    animFrame = requestAnimationFrame(drawFrame);
     const rows = Math.floor(canvas.height / FONT_SIZE);
     const t = window.APC.timing;
 
@@ -393,22 +426,14 @@ window.APC.boot = (function () {
 
       const y = (col.currentRow + 1) * FONT_SIZE;
 
-      // Emoji frequency re-rolled per character: random threshold between 1–5%.
-      const emojiThreshold = MATRIX_EMOJI_FREQUENCY_MIN +
-        Math.random() * (MATRIX_EMOJI_FREQUENCY_MAX - MATRIX_EMOJI_FREQUENCY_MIN);
-      const isEmoji = Math.random() < emojiThreshold;
+      // 2% of characters are emoji — natural OS color, no filter applied.
+      const isEmoji = Math.random() < t.MATRIX_EMOJI_FREQUENCY;
 
       if (isEmoji) {
-        // CSS emoji color filter hack: collapses emoji's native colors to black
-        // via brightness(0), then rebuilds to #00FF41 green through the filter chain.
-        ctx.filter =
-          'brightness(0) saturate(100%) invert(57%) sepia(99%) ' +
-          'saturate(400%) hue-rotate(85deg) brightness(110%)';
         ctx.fillText(
           MATRIX_EMOJIS[Math.floor(Math.random() * MATRIX_EMOJIS.length)],
           col.x, y
         );
-        ctx.filter = 'none';
       } else {
         ctx.fillStyle = MATRIX_COLOR;
         ctx.fillText(
@@ -422,7 +447,7 @@ window.APC.boot = (function () {
       if (col.currentRow >= rows) {
         col.pauseUntil = now + t.rand(t.MATRIX_RAIN_RESET_MIN_MS, t.MATRIX_RAIN_RESET_MAX_MS);
         col.currentRow = 0;
-        col.charDelay = t.rand(t.MATRIX_RAIN_CHAR_MIN_MS, t.MATRIX_RAIN_CHAR_MAX_MS);
+        // charDelay is NOT re-rolled — each column keeps its assigned speed for the full duration.
       }
 
       col.nextCharTime = now + col.charDelay;
@@ -436,7 +461,6 @@ window.APC.boot = (function () {
       const startY = canvas.height * t.MATRIX_IDENTITY_START_Y_PCT;
       const lineHeight = FONT_SIZE * 1.6;
 
-      ctx.filter = 'none'; // ensure no leftover filter from emoji columns
       ctx.font = FONT_SIZE + 'px "Courier New", monospace';
       ctx.fillStyle = MATRIX_COLOR;
 
@@ -1112,15 +1136,16 @@ window.APC.boot = (function () {
       try { bootAudio.chime.play().catch(function () {}); } catch (e) {}
     }
 
-    // Mark session as booted and fire analytics.
-    sessionStorage.setItem('boot_complete', '1');
+    // Record completion timestamp — used by localStorage TTL check on next page load.
+    // Return visits within 1 hour skip straight to desktop. After 1 hour: full experience replays.
+    localStorage.setItem('boot_complete_ts', Date.now());
     if (window.umami) { window.umami.track('boot_complete'); }
   }
 
-  // --- Desktop handoff (session restore path only) ---------------------
+  // --- Desktop handoff (localStorage TTL skip path only) --------------
   //
-  // Called when sessionStorage.boot_complete is already set — boot.js was never
-  // fully run this session, so bootAudio is null. Audio may not play (no gesture).
+  // Called when localStorage.boot_complete_ts is within the 1-hour TTL.
+  // bootAudio is null here — no gesture occurred. Audio may not play.
 
   function goToDesktop(skipDelay) {
     var chime = new Audio('assets/audio/startup.mp3');
@@ -1149,6 +1174,8 @@ window.APC.boot = (function () {
     identityPhase = 'waiting';
     identityTypedLines = [];
     currentLineIdx = 0;
+    rainDuration = 0;
+    rainStartTime = null;
     if (animFrame) { cancelAnimationFrame(animFrame); animFrame = null; }
 
     // Invalidate any in-flight boot screen callbacks.
@@ -1171,8 +1198,8 @@ window.APC.boot = (function () {
       window.APC.widgets.reset();
     }
 
-    // Clear session keys so init() runs the full sequence.
-    sessionStorage.removeItem('boot_complete');
+    // Clear localStorage TTL so init({ force:true }) replays the full experience.
+    localStorage.removeItem('boot_complete_ts');
     sessionStorage.removeItem('ne_history');
 
     // Reset DOM — hide desktop, clear open windows and taskbar buttons.
@@ -1215,8 +1242,8 @@ window.APC.boot = (function () {
       gatePrompt.style.top = '';
     }
 
-    // Re-run the boot init — sets up canvas, rain, and gate listeners.
-    init();
+    // Re-run the boot init — force:true bypasses localStorage TTL check.
+    init({ force: true });
   }
 
   // --- Shutdown screen -------------------------------------------------

--- a/js/taskbar.js
+++ b/js/taskbar.js
@@ -835,10 +835,9 @@ window.APC.taskbar = (function () {
     }
     // ~100ms tick lets the Umami call dispatch before state is cleared.
     setTimeout(function () {
-      // Remove only the keys this restart flow owns. sessionStorage.clear()
-      // would wipe unrelated state (audio unlock, resume gate) and conflicts
-      // with boot.restart() which also removes these keys explicitly.
-      sessionStorage.removeItem('boot_complete');
+      // Remove only the keys this restart flow owns. boot.restart() also
+      // removes these explicitly — belt-and-suspenders for safety.
+      localStorage.removeItem('boot_complete_ts');
       sessionStorage.removeItem('ne_history');
       if (window.APC.boot && typeof window.APC.boot.restart === 'function') {
         window.APC.boot.restart();

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -60,6 +60,14 @@
     MATRIX_RAIN_RESET_MAX_MS:       2500,
     MATRIX_RAIN_STAGGER_MAX_MS:     2000,  // max random start delay per column on init
 
+    MATRIX_DURATION_MIN_MS:         3000,  // minimum rain duration before prompt appears
+    MATRIX_DURATION_MAX_MS:        12000,  // maximum rain duration
+    MATRIX_COL_SPEED_MIN_PCT:       0.80,  // per-column speed floor (80% of base velocity)
+    MATRIX_COL_SPEED_MAX_PCT:       1.00,  // per-column speed ceiling (100% of base velocity)
+    MATRIX_EMOJI_FREQUENCY:         0.02,  // 2% of all characters are emoji (natural color)
+    MATRIX_CURSOR_BLINK_MS:          530,  // terminal prompt cursor blink interval (matches CSS)
+    MATRIX_SESSION_TTL_MS:       3600000,  // 1 hour — localStorage skip-to-desktop TTL
+
     // -------------------------------------------------------------------------
     // Boot Screen sequence
     // Fixed choreography — not latency simulation.


### PR DESCRIPTION
## Summary

Implements the finalized Matrix rain spec (#138). Four files changed.

### win98-timing.js — 7 new tokens
- `MATRIX_DURATION_MIN/MAX_MS`: 3000–12000ms (rain duration range)
- `MATRIX_COL_SPEED_MIN/MAX_PCT`: 0.80–1.00 (per-column speed range)
- `MATRIX_EMOJI_FREQUENCY`: 0.02 (2% of characters, fixed)
- `MATRIX_CURSOR_BLINK_MS`: 530 (documents existing CSS value)
- `MATRIX_SESSION_TTL_MS`: 3600000 (1-hour localStorage TTL)

### boot.js
- **`init(options)`** — `{ force: true }` bypasses localStorage TTL check; used by `restart()` and `doRestart()`
- **localStorage TTL** — `boot_complete_ts` replaces `sessionStorage.boot_complete`; return visits within 1hr skip rain + boot entirely; cold loads and post-1hr visits run the full experience
- **Randomized duration** — `rainDuration` rolled once in `init()`, checked each `drawFrame()`; rain stops and prompt appears when elapsed ≥ duration
- **Per-column fixed speed** — each column assigned `speedFactor` (0.80–1.00) at init; `charDelay = round(100ms / speedFactor)`; NOT re-rolled on column reset — speed persists for full duration
- **Emoji — natural color, no filter** — removed CSS filter hack; emojis render in native OS color; `MATRIX_EMOJI_FREQUENCY` (2%) replaces per-draw random threshold; new emoji list per spec
- **`restart()`** — resets `rainDuration`/`rainStartTime`, clears `localStorage.boot_complete_ts`, calls `init({ force: true })`

### taskbar.js
- `doRestart()`: `localStorage.removeItem('boot_complete_ts')` replaces `sessionStorage.removeItem('boot_complete')`

### js/CLAUDE.md
- New **Matrix Rain** section documenting TTL, duration, per-column speed, emoji color rules, and `init({ force })` API

Closes #138.

## Test plan
- [ ] Cold load: rain runs for 3–12s (varies between refreshes), then prompt appears
- [ ] Within 1hr of boot complete: page reload skips rain, goes straight to desktop
- [ ] After 1hr (or `localStorage.removeItem('boot_complete_ts')` in console): full rain runs again
- [ ] Columns fall at visibly different speeds; each column's speed is fixed for the duration
- [ ] Emoji appear in natural OS color — no green filter
- [ ] `window.APC.boot.init({ force: true })` in console: runs full rain regardless of TTL
- [ ] Start Menu → Restart: full rain plays; no TTL skip
- [ ] `localStorage.boot_complete_ts` is set after boot reaches COMPLETE
- [ ] No console errors on Chrome and Firefox desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)