### PR TITLE
feat: Matrix rain streaming rewrite — column streams, comet trail, mixed characters

### DIFF
--- a/css/boot.css
+++ b/css/boot.css
@@ -37,6 +37,8 @@
   user-select: none;
   opacity: 0;
   transition: opacity 300ms ease;
+  background: rgba(0, 0, 0, 0.75);
+  padding: 6px 12px;
 }
 
 /* Reveal class added by JS after identity line sequence completes */

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -104,17 +104,55 @@ The Matrix rain canvas runs inside `boot.js` under the `window.APC.boot` namespa
 - `rainStartTime` set on first `drawFrame()` call
 - When `Date.now() - rainStartTime >= rainDuration`: cancel rAF, call `revealPrompt()`
 
+**Column stream model (PR #141):**
+- Each column is a full visible stream of 8–20 characters falling as a unit (`col.streamLen`, set once at `initColumns()`, not re-rolled on reset)
+- `col.headRow` is the current row of the stream head (was `col.currentRow` before PR #141 — do not use the old name)
+- `col.active = false` during the post-exit pause; `col.pauseUntil` is the resume timestamp
+- Characters re-randomize every frame (flicker effect) — katakana, ASCII, emojis at 2%
+- When `col.headRow - col.streamLen + 1 >= rows` (tail fully off bottom): set `active = false`, roll new `pauseUntil`
+- On resume: `active = true`, `headRow = 0`, `nextCharTime = now` — `streamLen` and `charDelay` unchanged
+
 **Per-column fixed speed:**
-- Base velocity: 100ms per character step (documented in `initColumns()` comment)
+- Base velocity: 100ms per head advance (documented in `initColumns()` comment)
 - Each column gets `speedFactor = rand(MATRIX_COL_SPEED_MIN_PCT, MATRIX_COL_SPEED_MAX_PCT)` (0.80–1.00)
 - `col.charDelay = Math.round(100 / speedFactor)` → range 100–125ms
-- charDelay is NOT re-rolled when a column resets to the top — speed is fixed for the full duration
+- charDelay is NOT re-rolled when a stream resets — speed is fixed for the full duration
+
+**Trail opacity — exact values, implement these:**
+
+| Position (j) | Opacity |
+|---|---|
+| 0 (head) | 1.0 |
+| 1 | 0.8 |
+| 2 | 0.6 |
+| 3 | 0.4 |
+| 4+ | 0.2, linear taper to 0 at stream tail |
+
+Defined in `TRAIL_OPACITIES` const in boot.js. Set `ctx.globalAlpha = opacity` per character; restore to 1.0 after the column loop.
+
+**Render model — clearRect (PR #141):**
+- `drawFrame()` calls `ctx.clearRect(0, 0, canvas.width, canvas.height)` at the start of every frame
+- All active stream cells are re-drawn explicitly
+- Do NOT restore the old `rgba(0,0,0,0.15)` `fillRect` overdraw — it is replaced
+
+**Prompt legibility:**
+- `#gate-prompt` has `background: rgba(0,0,0,0.75)` and `padding: 6px 12px` in `css/boot.css`
+- Do not remove these — the streaming rain runs behind the prompt
+
+**`revealPrompt()`:**
+- Calls `cancelAnimationFrame(animFrame)` before showing the prompt — rain stops when prompt appears
+- `identityPhase = 'done'` and the `gate-prompt--visible` class are set after the cancel
 
 **Emoji rendering — natural color, no filter:**
 - Frequency: exactly `MATRIX_EMOJI_FREQUENCY` (2%) — fixed, not re-rolled per character
 - Emojis render in natural OS color. No CSS filter. Do not add a filter.
 - Do NOT use the old `ctx.filter = 'brightness(0) saturate(100%)...'` hack — it is removed
 - Emoji list is defined in `MATRIX_EMOJIS` const in boot.js
+
+**Wormhole compatibility (`startWormhole()`):**
+- Snapshots `col.headRow` (not `col.currentRow`) when building `wormChars`
+- Clamp negative headRow values (above-canvas streams) to 0: `Math.max(0, col.headRow)`
+- Everything else in `startWormhole()` is unaffected by the streaming rewrite
 
 **`init(options)` signature:**
 - `options.force = true` bypasses the localStorage TTL check

--- a/js/boot.js
+++ b/js/boot.js
@@ -13,6 +13,9 @@ window.APC.boot = (function () {
 
   const MATRIX_COLOR = '#00FF41';
   const FONT_SIZE = 14;
+  // Trail opacity by stream position (j=0 is head, j=1 next, etc.).
+  // Positions beyond this array taper linearly from 0.2 toward 0 at stream tail.
+  const TRAIL_OPACITIES = [1.0, 0.8, 0.6, 0.4, 0.2];
   // Emoji frequency is fixed at MATRIX_EMOJI_FREQUENCY (2%) — no per-draw re-roll.
 
   // Exact character set from CLAUDE.md spec — half-width katakana + ASCII + symbols.
@@ -339,6 +342,8 @@ window.APC.boot = (function () {
 
   function revealPrompt() {
     if (hasStarted) { return; }
+    // Cancel the rain rAF — prompt is visible, rain is no longer needed.
+    if (animFrame) { cancelAnimationFrame(animFrame); animFrame = null; }
     identityPhase = 'done';
     const prompt = document.getElementById('gate-prompt');
     if (prompt) {
@@ -371,30 +376,36 @@ window.APC.boot = (function () {
   function initColumns() {
     const t = window.APC.timing;
     const count = Math.floor(canvas.width / FONT_SIZE);
-    const rows = Math.floor(canvas.height / FONT_SIZE);
-    // Base velocity: 100ms per character step — tuned for readability at 1080p desktop.
+    // Base velocity: 100ms per head advance — tuned for readability at 1080p desktop.
     // Each column's charDelay = BASE_CHAR_DELAY_MS / speedFactor, giving a fixed
     // 100–125ms range (MATRIX_COL_SPEED_MIN_PCT 0.80 → 125ms, MAX 1.00 → 100ms).
+    // charDelay is NOT re-rolled when a stream resets — speed is fixed for the full duration.
     const BASE_CHAR_DELAY_MS = 100;
     columns = [];
     for (let i = 0; i < count; i++) {
       const speedFactor = t.MATRIX_COL_SPEED_MIN_PCT +
         Math.random() * (t.MATRIX_COL_SPEED_MAX_PCT - t.MATRIX_COL_SPEED_MIN_PCT);
+      const streamLen = t.rand(t.MATRIX_STREAM_LEN_MIN, t.MATRIX_STREAM_LEN_MAX);
       columns.push({
-        x: i * FONT_SIZE,
-        currentRow: Math.floor(Math.random() * rows),
-        nextCharTime: Date.now() + Math.floor(Math.random() * t.MATRIX_RAIN_STAGGER_MAX_MS),
-        charDelay: Math.round(BASE_CHAR_DELAY_MS / speedFactor), // fixed for duration — no re-roll
-        pauseUntil: 0
+        x:            i * FONT_SIZE,
+        headRow:      -Math.floor(Math.random() * streamLen), // stagger: head starts above canvas
+        streamLen:    streamLen,                               // fixed for duration — not re-rolled on reset
+        speedFactor:  speedFactor,
+        charDelay:    Math.round(BASE_CHAR_DELAY_MS / speedFactor), // fixed for duration
+        nextCharTime: Date.now() + t.rand(0, t.MATRIX_RAIN_STAGGER_MAX_MS),
+        active:       true,
+        pauseUntil:   0
       });
     }
   }
 
   // --- Matrix rain render loop -----------------------------------------
   //
-  // Per-column typing reveal: each column advances one character at a time,
-  // top to bottom, at a randomised 40–180ms cadence. Identity lines are
-  // redrawn at full brightness each frame so the fade overlay doesn't dim them.
+  // Column stream model: each column maintains a full visible stream of
+  // N characters (8–20) falling together as a unit. The head advances one
+  // row per tick; the trail follows above it, fading by position. Characters
+  // re-randomize every frame (flicker effect). clearRect replaces overdraw —
+  // all active cells are re-drawn explicitly each frame.
 
   function drawFrame() {
     const now = Date.now();
@@ -412,57 +423,83 @@ window.APC.boot = (function () {
     const rows = Math.floor(canvas.height / FONT_SIZE);
     const t = window.APC.timing;
 
-    // Fade-to-black trail — dims older characters naturally each frame.
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.15)';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    // Clear full canvas each frame — streaming model re-draws all active cells explicitly.
+    // Replaces the old rgba(0,0,0,0.15) overdraw; canvas background shows through cleared cells.
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     ctx.font = FONT_SIZE + 'px "Courier New", monospace';
+    ctx.fillStyle = MATRIX_COLOR;
 
     for (let i = 0; i < columns.length; i++) {
       const col = columns[i];
 
-      if (now < col.pauseUntil) { continue; }
-      if (now < col.nextCharTime) { continue; }
-
-      const y = (col.currentRow + 1) * FONT_SIZE;
-
-      // 2% of characters are emoji — natural OS color, no filter applied.
-      const isEmoji = Math.random() < t.MATRIX_EMOJI_FREQUENCY;
-
-      if (isEmoji) {
-        ctx.fillText(
-          MATRIX_EMOJIS[Math.floor(Math.random() * MATRIX_EMOJIS.length)],
-          col.x, y
-        );
-      } else {
-        ctx.fillStyle = MATRIX_COLOR;
-        ctx.fillText(
-          MATRIX_CHARS[Math.floor(Math.random() * MATRIX_CHARS.length)],
-          col.x, y
-        );
+      if (!col.active) {
+        if (now >= col.pauseUntil) {
+          col.active = true;
+          col.headRow = 0;
+          col.nextCharTime = now;
+        }
+        continue;
       }
 
-      col.currentRow++;
+      // Advance head one row per tick.
+      if (now >= col.nextCharTime) {
+        col.headRow++;
+        col.nextCharTime = now + col.charDelay;
+      }
 
-      if (col.currentRow >= rows) {
+      // Stream fully exited — begin post-exit pause.
+      // Check tail (headRow - streamLen + 1) rather than head so the full stream clears.
+      if (col.headRow - col.streamLen + 1 >= rows) {
+        col.active = false;
         col.pauseUntil = now + t.rand(t.MATRIX_RAIN_RESET_MIN_MS, t.MATRIX_RAIN_RESET_MAX_MS);
-        col.currentRow = 0;
-        // charDelay is NOT re-rolled — each column keeps its assigned speed for the full duration.
+        continue;
       }
 
-      col.nextCharTime = now + col.charDelay;
+      // Draw stream — head at headRow, trail going upward (j=0 is head).
+      // Characters re-randomize every frame for flicker effect.
+      for (let j = 0; j < col.streamLen; j++) {
+        const row = col.headRow - j;
+        if (row < 0 || row >= rows) { continue; }
+
+        let opacity;
+        if (j < TRAIL_OPACITIES.length) {
+          opacity = TRAIL_OPACITIES[j];
+        } else {
+          // Linear taper: 0.2 at TRAIL_OPACITIES.length → 0 at stream tail.
+          const tailLen = col.streamLen - TRAIL_OPACITIES.length;
+          opacity = tailLen > 0 ? 0.2 * (1 - (j - TRAIL_OPACITIES.length) / tailLen) : 0;
+        }
+        if (opacity <= 0) { continue; }
+
+        const y = (row + 1) * FONT_SIZE;
+        ctx.globalAlpha = opacity;
+
+        if (Math.random() < t.MATRIX_EMOJI_FREQUENCY) {
+          // 2% of characters are emoji — natural OS color, no filter applied.
+          ctx.fillText(
+            MATRIX_EMOJIS[Math.floor(Math.random() * MATRIX_EMOJIS.length)],
+            col.x, y
+          );
+        } else {
+          ctx.fillText(
+            MATRIX_CHARS[Math.floor(Math.random() * MATRIX_CHARS.length)],
+            col.x, y
+          );
+        }
+      }
     }
 
-    // Redraw identity lines at full brightness each frame so the fade overlay
-    // doesn't dim them while they're still being typed.
-    // Y positions recalculate from canvas.height on each frame so a resize
-    // mid-sequence doesn't leave lines at stale vertical positions.
+    // Restore defaults before drawing identity lines.
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = MATRIX_COLOR;
+
+    // Redraw identity lines at full brightness each frame so they're always
+    // visible over the streaming rain. Y positions recalculate from canvas.height
+    // on each frame so a resize mid-sequence doesn't leave lines at stale positions.
     if (identityPhase !== 'waiting' && identityTypedLines.length > 0) {
       const startY = canvas.height * t.MATRIX_IDENTITY_START_Y_PCT;
       const lineHeight = FONT_SIZE * 1.6;
-
-      ctx.font = FONT_SIZE + 'px "Courier New", monospace';
-      ctx.fillStyle = MATRIX_COLOR;
 
       for (let li = 0; li < identityTypedLines.length; li++) {
         if (!identityTypedLines[li]) { continue; }
@@ -1337,7 +1374,8 @@ window.APC.boot = (function () {
         if (Math.random() > 0.6) { continue; }
         var px  = col.x + FONT_SIZE / 2;
         // Distribute rows relative to column's live rain-head position.
-        var row = (col.currentRow + ri) % gridRows;
+        // Clamp negative headRow values (above-canvas streams) to 0.
+        var row = (Math.max(0, col.headRow) + ri) % gridRows;
         var py  = (row + 1) * FONT_SIZE;
         var dx  = px - cx;
         var dy  = py - cy;

--- a/js/boot.js
+++ b/js/boot.js
@@ -2,7 +2,7 @@
 // Sequence: gate → keypress → POST → IBS_SPLASH → DOS_LOG → WINDOORS_LOGO → DESKTOP_ARRIVAL → COMPLETE
 // Namespaced under window.APC per project conventions.
 // All timing values sourced from window.APC.timing (js/win98-timing.js).
-// Issues implemented: #86, #87, #89, #90, #91, #92, #93, #94.
+// Issues implemented: #86, #87, #89, #90, #91, #92, #93, #94, #141.
 
 window.APC = window.APC || {};
 

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -54,8 +54,6 @@
 
     // Rain column typing pace — per-column typing reveal model.
     // Columns advance one character at a time at a randomised speed.
-    MATRIX_RAIN_CHAR_MIN_MS:          40,  // fastest column (programmer typing speed)
-    MATRIX_RAIN_CHAR_MAX_MS:         180,  // slowest column
     MATRIX_RAIN_RESET_MIN_MS:        800,  // pause after column fills before reset to top
     MATRIX_RAIN_RESET_MAX_MS:       2500,
     MATRIX_RAIN_STAGGER_MAX_MS:     2000,  // max random start delay per column on init

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -65,6 +65,8 @@
     MATRIX_COL_SPEED_MIN_PCT:       0.80,  // per-column speed floor (80% of base velocity)
     MATRIX_COL_SPEED_MAX_PCT:       1.00,  // per-column speed ceiling (100% of base velocity)
     MATRIX_EMOJI_FREQUENCY:         0.02,  // 2% of all characters are emoji (natural color)
+    MATRIX_STREAM_LEN_MIN:             8,  // min visible characters per column stream
+    MATRIX_STREAM_LEN_MAX:            20,  // max visible characters per column stream
     MATRIX_CURSOR_BLINK_MS:          530,  // terminal prompt cursor blink interval (matches CSS)
     MATRIX_SESSION_TTL_MS:       3600000,  // 1 hour — localStorage skip-to-desktop TTL
 


### PR DESCRIPTION
Closes #141

## What changed

| File | Change |
|------|--------|
| `js/boot.js` | Rewrite `initColumns()` and `drawFrame()` — new stream data model, clearRect render, trail opacities; add `cancelAnimationFrame` to `revealPrompt()`; update `startWormhole()` with `col.headRow` + negative clamp |
| `js/win98-timing.js` | Add `MATRIX_STREAM_LEN_MIN: 8`, `MATRIX_STREAM_LEN_MAX: 20` |
| `css/boot.css` | Add `background: rgba(0,0,0,0.75)` and `padding: 6px 12px` to `#gate-prompt` |
| `js/CLAUDE.md` | Update Matrix Rain section: stream model, trail opacity table, clearRect model, wormhole note, revealPrompt contract |

## What the rewrite does

**Before:** Each column advances one character at a time, top to bottom, at 100–125ms per step. The `rgba(0,0,0,0.15)` overdraw at 60fps dims old characters into a trail — but at ~8 advances/sec vs 60 overdraw passes/sec, the canvas goes dark faster than columns can paint it.

**After:** Each column is a full stream of 8–20 characters (`col.streamLen`) falling together as a unit. `col.headRow` tracks the leading character; the trail above it fades at exact opacity steps (1.0 → 0.8 → 0.6 → 0.4 → 0.2 → linear taper to 0). Characters re-randomize every frame for a continuous flicker effect. `clearRect` at frame start replaces the overdraw — every active cell is re-drawn explicitly.

## Data model change

`col.currentRow` → `col.headRow`. New fields: `col.streamLen` (fixed at init, not re-rolled on reset), `col.active` (false during post-exit pause). All existing fields (`x`, `charDelay`, `speedFactor`, `nextCharTime`, `pauseUntil`) kept unchanged.

## Manual QA checklist

- [ ] Rain shows full column streams (8–20 chars tall) falling simultaneously — not single advancing dots
- [ ] Head character is bright `#00FF41`; trail visibly fades over 4–5 positions
- [ ] Characters flicker (re-randomize) every frame — no frozen streams
- [ ] Emojis appear at ~2% frequency mixed into streams
- [ ] Columns pause after exiting the bottom, then restart from the top
- [ ] Identity lines remain readable over the rain
- [ ] `#gate-prompt` is legible over the rain (backdrop visible)
- [ ] Wormhole animation looks correct after keypress (spiral, collapse, desk reveal)
- [ ] `restart()` via Start Menu → Shut Down → Restart replays full gate + rain
- [ ] No jank at 1080p (Performance panel: sustained 60fps)
- [ ] localStorage TTL skip (visit within 1 hour) still works