### PR TITLE
fix: rain stops behind prompt, streams too short, black top

### DIFF
--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -102,10 +102,11 @@ The Matrix rain canvas runs inside `boot.js` under the `window.APC.boot` namespa
 - `rainDuration = rand(MATRIX_DURATION_MIN_MS, MATRIX_DURATION_MAX_MS)` (3–12s)
 - Chosen once in `init()`, stored in `rainDuration`, reset to 0 on `restart()`
 - `rainStartTime` set on first `drawFrame()` call
-- When `Date.now() - rainStartTime >= rainDuration`: cancel rAF, call `revealPrompt()`
+- When `Date.now() - rainStartTime >= rainDuration` and `identityPhase !== 'done'`: call `revealPrompt()` — rain keeps running
 
-**Column stream model (PR #141):**
-- Each column is a full visible stream of 8–20 characters falling as a unit (`col.streamLen`, set once at `initColumns()`, not re-rolled on reset)
+**Column stream model (PR #141, #143):**
+- Each column is a full visible stream of 15–80 characters falling as a unit (`col.streamLen`, set once at `initColumns()`, not re-rolled on reset)
+- `MATRIX_STREAM_LEN_MAX: 80` intentionally exceeds the ~77 rows visible at 1080p — long streams run top-to-bottom with no visible tail end; the inner loop clips at canvas bounds
 - `col.headRow` is the current row of the stream head (was `col.currentRow` before PR #141 — do not use the old name)
 - `col.active = false` during the post-exit pause; `col.pauseUntil` is the resume timestamp
 - Characters re-randomize every frame (flicker effect) — katakana, ASCII, emojis at 2%
@@ -140,8 +141,9 @@ Defined in `TRAIL_OPACITIES` const in boot.js. Set `ctx.globalAlpha = opacity` p
 - Do not remove these — the streaming rain runs behind the prompt
 
 **`revealPrompt()`:**
-- Calls `cancelAnimationFrame(animFrame)` before showing the prompt — rain stops when prompt appears
-- `identityPhase = 'done'` and the `gate-prompt--visible` class are set after the cancel
+- Sets `identityPhase = 'done'` and adds `gate-prompt--visible` — that is all it does
+- Does NOT cancel rAF. Rain runs continuously behind the prompt until the user interacts
+- rAF is cancelled only by `startWormhole()` when the user clicks or presses a key
 
 **Emoji rendering — natural color, no filter:**
 - Frequency: exactly `MATRIX_EMOJI_FREQUENCY` (2%) — fixed, not re-rolled per character

--- a/js/boot.js
+++ b/js/boot.js
@@ -342,8 +342,6 @@ window.APC.boot = (function () {
 
   function revealPrompt() {
     if (hasStarted) { return; }
-    // Cancel the rain rAF — prompt is visible, rain is no longer needed.
-    if (animFrame) { cancelAnimationFrame(animFrame); animFrame = null; }
     identityPhase = 'done';
     const prompt = document.getElementById('gate-prompt');
     if (prompt) {
@@ -410,13 +408,10 @@ window.APC.boot = (function () {
   function drawFrame() {
     const now = Date.now();
 
-    // Duration check — stop rain and reveal prompt when time is up.
+    // Duration check — reveal prompt when time is up. Rain keeps running.
     if (rainStartTime === null) { rainStartTime = now; }
-    if (!hasStarted && (now - rainStartTime) >= rainDuration) {
-      cancelAnimationFrame(animFrame);
-      animFrame = null;
+    if (!hasStarted && rainStartTime !== null && (now - rainStartTime) >= rainDuration && identityPhase !== 'done') {
       revealPrompt();
-      return;
     }
 
     animFrame = requestAnimationFrame(drawFrame);

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -54,8 +54,8 @@
 
     // Rain column typing pace — per-column typing reveal model.
     // Columns advance one character at a time at a randomised speed.
-    MATRIX_RAIN_RESET_MIN_MS:        800,  // pause after column fills before reset to top
-    MATRIX_RAIN_RESET_MAX_MS:       2500,
+    MATRIX_RAIN_RESET_MIN_MS:          0,  // no pause between streams — columns restart immediately
+    MATRIX_RAIN_RESET_MAX_MS:          0,
     MATRIX_RAIN_STAGGER_MAX_MS:     2000,  // max random start delay per column on init
 
     MATRIX_DURATION_MIN_MS:         3000,  // minimum rain duration before prompt appears
@@ -63,8 +63,8 @@
     MATRIX_COL_SPEED_MIN_PCT:       0.80,  // per-column speed floor (80% of base velocity)
     MATRIX_COL_SPEED_MAX_PCT:       1.00,  // per-column speed ceiling (100% of base velocity)
     MATRIX_EMOJI_FREQUENCY:         0.02,  // 2% of all characters are emoji (natural color)
-    MATRIX_STREAM_LEN_MIN:             8,  // min visible characters per column stream
-    MATRIX_STREAM_LEN_MAX:            20,  // max visible characters per column stream
+    MATRIX_STREAM_LEN_MIN:            15,  // min visible characters per column stream
+    MATRIX_STREAM_LEN_MAX:            80,  // max — exceeds screen rows; tail clips naturally at canvas edge
     MATRIX_CURSOR_BLINK_MS:          530,  // terminal prompt cursor blink interval (matches CSS)
     MATRIX_SESSION_TTL_MS:       3600000,  // 1 hour — localStorage skip-to-desktop TTL
 


### PR DESCRIPTION
Closes #143

Three QA regressions from #142, each with a targeted fix.

## Fixes

**1. Rain freezes when prompt appears**

`revealPrompt()` was calling `cancelAnimationFrame(animFrame)` — removed entirely. Rain now runs continuously behind the `C:\>` prompt. The rAF is only cancelled by `startWormhole()` when the user interacts.

The duration check in `drawFrame()` was also cancelling rAF and returning early. Replaced with a non-terminating condition (`identityPhase !== 'done'` guard prevents repeat calls). Frame re-queues normally every tick.

**2. Streams too short**

`MATRIX_STREAM_LEN_MAX: 20` → `80`. At 14px font, 80 chars exceeds the ~77 rows visible at 1080p. The inner loop already bounds-checks `row < 0 || row >= rows`, so long streams simply run top-to-bottom with no visible tail end — the "infinite trail" effect.

**3. Black upper canvas**

`MATRIX_RAIN_RESET_MIN/MAX_MS: 800–2500` → `0`. No pause between streams. Combined with the staggered init (`MATRIX_RAIN_STAGGER_MAX_MS: 2000`), columns are offset so the canvas stays fully dense at all times.

## Files changed

| File | Change |
|------|--------|
| `js/boot.js` | Remove `cancelAnimationFrame` from `revealPrompt()`; restructure duration block to not cancel rAF or return early |
| `js/win98-timing.js` | `MATRIX_STREAM_LEN_MIN: 15`, `MATRIX_STREAM_LEN_MAX: 80`, `MATRIX_RAIN_RESET_MIN/MAX_MS: 0` |
| `js/CLAUDE.md` | Update rain duration note and `revealPrompt()` contract |

## QA checklist

- [ ] Rain runs continuously behind `C:\> press any key to continue_` — no freeze
- [ ] Some streams visibly span full screen height top to bottom
- [ ] No large black areas in the upper canvas
- [ ] Prompt legible over the rain (existing backdrop sufficient)
- [ ] Clicking/keypressing triggers wormhole correctly — no stale rAF state
- [ ] `restart()` replays clean rain from scratch