### PR TITLE
fix: remove localStorage TTL skip — every visit gets the full boot experience

### DIFF
--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -92,11 +92,11 @@ Never call `sessionStorage.clear()`. Use targeted `removeItem()` only.
 
 The Matrix rain canvas runs inside `boot.js` under the `window.APC.boot` namespace. There is no separate `matrix.js`.
 
-**Session persistence — localStorage TTL:**
-- On boot completion: `localStorage.setItem('boot_complete_ts', Date.now())`
-- On page load (`init()`): if `boot_complete_ts` exists and is < 1 hour old (`MATRIX_SESSION_TTL_MS`), skip rain + boot, go straight to desktop
-- Bypass with `window.APC.boot.init({ force: true })` — used by `restart()` and taskbar `doRestart()`
-- Do NOT use `sessionStorage` for boot-skip logic. `sessionStorage.boot_complete` is removed.
+**Session persistence — localStorage TTL (disabled):**
+- `MATRIX_SESSION_TTL_MS` is `0` — the TTL skip is permanently unreachable. Every visit gets the full gate → boot experience.
+- `boot_complete_ts` is no longer written to localStorage. The read in `init()` still exists but the skip condition (`elapsed < 0`) is never true.
+- `init({ force: true })` still works correctly — bypasses the TTL check, used by `restart()`.
+- Do NOT restore the `localStorage.setItem('boot_complete_ts', ...)` call. Do NOT set `MATRIX_SESSION_TTL_MS` above 0.
 
 **Rain duration — randomized at init time:**
 - `rainDuration = rand(MATRIX_DURATION_MIN_MS, MATRIX_DURATION_MAX_MS)` (3–12s)

--- a/js/boot.js
+++ b/js/boot.js
@@ -1168,9 +1168,6 @@ window.APC.boot = (function () {
       try { bootAudio.chime.play().catch(function () {}); } catch (e) {}
     }
 
-    // Record completion timestamp — used by localStorage TTL check on next page load.
-    // Return visits within 1 hour skip straight to desktop. After 1 hour: full experience replays.
-    localStorage.setItem('boot_complete_ts', Date.now());
     if (window.umami) { window.umami.track('boot_complete'); }
   }
 
@@ -1230,8 +1227,6 @@ window.APC.boot = (function () {
       window.APC.widgets.reset();
     }
 
-    // Clear localStorage TTL so init({ force:true }) replays the full experience.
-    localStorage.removeItem('boot_complete_ts');
     sessionStorage.removeItem('ne_history');
 
     // Reset DOM — hide desktop, clear open windows and taskbar buttons.

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -66,7 +66,7 @@
     MATRIX_STREAM_LEN_MIN:            15,  // min visible characters per column stream
     MATRIX_STREAM_LEN_MAX:            80,  // max — exceeds screen rows; tail clips naturally at canvas edge
     MATRIX_CURSOR_BLINK_MS:          530,  // terminal prompt cursor blink interval (matches CSS)
-    MATRIX_SESSION_TTL_MS:       3600000,  // 1 hour — localStorage skip-to-desktop TTL
+    MATRIX_SESSION_TTL_MS:             0,  // TTL disabled — every visit gets the full boot experience
 
     // -------------------------------------------------------------------------
     // Boot Screen sequence


### PR DESCRIPTION
Closes #145

## What changed

`MATRIX_SESSION_TTL_MS: 0` — the skip condition (`elapsed < 0`) is now permanently unreachable. Every visit plays the full gate → Matrix rain → wormhole → desk scene → boot sequence.

Removed the `localStorage.setItem('boot_complete_ts', ...)` write from `handleBootComplete()` — no point writing a timestamp that's never checked against. Removed the matching `localStorage.removeItem` from `restart()` for the same reason.

`init({ force: true })` and `restart()` are unaffected — the `force` flag bypasses the TTL check entirely.

## Files changed

| File | Change |
|------|--------|
| `js/win98-timing.js` | `MATRIX_SESSION_TTL_MS: 0` |
| `js/boot.js` | Remove `localStorage.setItem` from `handleBootComplete()`; remove `localStorage.removeItem` from `restart()` |
| `js/CLAUDE.md` | Update localStorage TTL section — disabled, do not restore |

## QA checklist

- [ ] Hard refresh after completing boot plays the full sequence again — no skip to desktop
- [ ] `boot_complete_ts` is not written to localStorage after boot completes (check DevTools → Application → Local Storage)
- [ ] `restart()` via Start Menu → Shut Down → Restart still works correctly
- [ ] No console errors