### PR TITLE
polish: matrix rain — emoji-only streams, longer trail visibility, 25% slower speed

### DIFF
--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -104,57 +104,49 @@ The Matrix rain canvas runs inside `boot.js` under the `window.APC.boot` namespa
 - `rainStartTime` set on first `drawFrame()` call
 - When `Date.now() - rainStartTime >= rainDuration` and `identityPhase !== 'done'`: call `revealPrompt()` — rain keeps running
 
-**Column stream model (PR #141, #143):**
-- Each column is a full visible stream of 15–80 characters falling as a unit (`col.streamLen`, set once at `initColumns()`, not re-rolled on reset)
-- `MATRIX_STREAM_LEN_MAX: 80` intentionally exceeds the ~77 rows visible at 1080p — long streams run top-to-bottom with no visible tail end; the inner loop clips at canvas bounds
-- `col.headRow` is the current row of the stream head (was `col.currentRow` before PR #141 — do not use the old name)
-- `col.active = false` during the post-exit pause; `col.pauseUntil` is the resume timestamp
-- Characters re-randomize every frame (flicker effect) — katakana, ASCII, emojis at 2%
-- When `col.headRow - col.streamLen + 1 >= rows` (tail fully off bottom): set `active = false`, roll new `pauseUntil`
-- On resume: `active = true`, `headRow = 0`, `nextCharTime = now` — `streamLen` and `charDelay` unchanged
+**Column data model (PRs #141, #143, #147):**
+- `col.headRow` — current row of the stream head (was `col.currentRow` before PR #141 — do not use the old name)
+- `col.streamLen` — set once at `initColumns()`, not re-rolled on reset; retained in the object but does not affect the overdraw trail model
+- `col.emojiStream` — `true` for ~1% of columns (decided by `MATRIX_EMOJI_STREAM_CHANCE`); never re-rolled. `true` = emoji-only column; `false` = katakana/ASCII only, no emojis
+- `col.active` — `false` during post-exit pause; `col.pauseUntil` is the resume timestamp
+- On resume: `active = true`, `headRow = 0`, `nextCharTime = now`
+- Exit condition: `col.headRow >= rows` (head exits the bottom — no virtual tail travel)
 
 **Per-column fixed speed:**
-- Base velocity: 100ms per head advance (documented in `initColumns()` comment)
+- Base velocity: `MATRIX_STREAM_BASE_DELAY_MS` (125ms) per head advance
 - Each column gets `speedFactor = rand(MATRIX_COL_SPEED_MIN_PCT, MATRIX_COL_SPEED_MAX_PCT)` (0.80–1.00)
-- `col.charDelay = Math.round(100 / speedFactor)` → range 100–125ms
+- `col.charDelay = Math.round(125 / speedFactor)` → range 125–156ms
 - charDelay is NOT re-rolled when a stream resets — speed is fixed for the full duration
 
-**Trail opacity — exact values, implement these:**
+**Render model — overdraw trail (PR #147):**
+- Each frame: `ctx.fillStyle = 'rgba(0, 0, 0, ' + MATRIX_TRAIL_OVERDRAW_ALPHA + ')'; ctx.fillRect(...)` dims all previous content
+- Then draw only the **head character** for each active column at full brightness
+- The comet trail is formed by previous frames fading — not explicit position opacities
+- At `MATRIX_TRAIL_OVERDRAW_ALPHA: 0.05` (~60fps): character fades to ~5% brightness in ~57 frames (~1s), giving ~8 visible rows of trail
+- Do NOT use `clearRect` — it removes the trail entirely. Do NOT draw multiple positions per column — it defeats the overdraw fade
+- Do NOT add `ctx.globalAlpha` management to the column draw loop — head is always full brightness
 
-| Position (j) | Opacity |
-|---|---|
-| 0 (head) | 1.0 |
-| 1 | 0.8 |
-| 2 | 0.6 |
-| 3 | 0.4 |
-| 4+ | 0.2, linear taper to 0 at stream tail |
-
-Defined in `TRAIL_OPACITIES` const in boot.js. Set `ctx.globalAlpha = opacity` per character; restore to 1.0 after the column loop.
-
-**Render model — clearRect (PR #141):**
-- `drawFrame()` calls `ctx.clearRect(0, 0, canvas.width, canvas.height)` at the start of every frame
-- All active stream cells are re-drawn explicitly
-- Do NOT restore the old `rgba(0,0,0,0.15)` `fillRect` overdraw — it is replaced
+**Emoji rendering — natural color, no filter:**
+- 1% of columns are `emojiStream: true` — every character in that column is an emoji
+- Remaining 99% are katakana/ASCII only — no emojis mixed in
+- `MATRIX_EMOJI_FREQUENCY` is superseded by the `emojiStream` model — do not use it for drawing decisions
+- Emojis render in natural OS color. No CSS filter. Do not add a filter.
+- Do NOT use the old `ctx.filter = 'brightness(0) saturate(100%)...'` hack — it is removed
+- Emoji list is defined in `MATRIX_EMOJIS` const in boot.js
 
 **Prompt legibility:**
 - `#gate-prompt` has `background: rgba(0,0,0,0.75)` and `padding: 6px 12px` in `css/boot.css`
-- Do not remove these — the streaming rain runs behind the prompt
+- Do not remove these — the rain runs behind the prompt
 
 **`revealPrompt()`:**
 - Sets `identityPhase = 'done'` and adds `gate-prompt--visible` — that is all it does
 - Does NOT cancel rAF. Rain runs continuously behind the prompt until the user interacts
 - rAF is cancelled only by `startWormhole()` when the user clicks or presses a key
 
-**Emoji rendering — natural color, no filter:**
-- Frequency: exactly `MATRIX_EMOJI_FREQUENCY` (2%) — fixed, not re-rolled per character
-- Emojis render in natural OS color. No CSS filter. Do not add a filter.
-- Do NOT use the old `ctx.filter = 'brightness(0) saturate(100%)...'` hack — it is removed
-- Emoji list is defined in `MATRIX_EMOJIS` const in boot.js
-
 **Wormhole compatibility (`startWormhole()`):**
 - Snapshots `col.headRow` (not `col.currentRow`) when building `wormChars`
-- Clamp negative headRow values (above-canvas streams) to 0: `Math.max(0, col.headRow)`
-- Everything else in `startWormhole()` is unaffected by the streaming rewrite
+- Clamp negative headRow values to 0: `Math.max(0, col.headRow)` (columns init within canvas now, so this is a safety guard)
+- Everything else in `startWormhole()` is unaffected
 
 **`init(options)` signature:**
 - `options.force = true` bypasses the localStorage TTL check

--- a/js/boot.js
+++ b/js/boot.js
@@ -13,10 +13,8 @@ window.APC.boot = (function () {
 
   const MATRIX_COLOR = '#00FF41';
   const FONT_SIZE = 14;
-  // Trail opacity by stream position (j=0 is head, j=1 next, etc.).
-  // Positions beyond this array taper linearly from 0.2 toward 0 at stream tail.
-  const TRAIL_OPACITIES = [1.0, 0.8, 0.6, 0.4, 0.2];
-  // Emoji frequency is fixed at MATRIX_EMOJI_FREQUENCY (2%) — no per-draw re-roll.
+  // Emoji columns: 1% of columns are emoji-only (emojiStream flag set in initColumns).
+  // The remaining 99% are katakana/ASCII only — no per-character emoji roll.
 
   // Exact character set from CLAUDE.md spec — half-width katakana + ASCII + symbols.
   const MATRIX_CHARS = [
@@ -374,11 +372,12 @@ window.APC.boot = (function () {
   function initColumns() {
     const t = window.APC.timing;
     const count = Math.floor(canvas.width / FONT_SIZE);
-    // Base velocity: 100ms per head advance — tuned for readability at 1080p desktop.
+    const rows = Math.floor(canvas.height / FONT_SIZE);
+    // Base velocity: MATRIX_STREAM_BASE_DELAY_MS per head advance (125ms — 25% slower than original).
     // Each column's charDelay = BASE_CHAR_DELAY_MS / speedFactor, giving a fixed
-    // 100–125ms range (MATRIX_COL_SPEED_MIN_PCT 0.80 → 125ms, MAX 1.00 → 100ms).
+    // 125–156ms range (MATRIX_COL_SPEED_MIN_PCT 0.80 → 156ms, MAX 1.00 → 125ms).
     // charDelay is NOT re-rolled when a stream resets — speed is fixed for the full duration.
-    const BASE_CHAR_DELAY_MS = 100;
+    const BASE_CHAR_DELAY_MS = t.MATRIX_STREAM_BASE_DELAY_MS;
     columns = [];
     for (let i = 0; i < count; i++) {
       const speedFactor = t.MATRIX_COL_SPEED_MIN_PCT +
@@ -386,8 +385,9 @@ window.APC.boot = (function () {
       const streamLen = t.rand(t.MATRIX_STREAM_LEN_MIN, t.MATRIX_STREAM_LEN_MAX);
       columns.push({
         x:            i * FONT_SIZE,
-        headRow:      -Math.floor(Math.random() * streamLen), // stagger: head starts above canvas
-        streamLen:    streamLen,                               // fixed for duration — not re-rolled on reset
+        headRow:      t.rand(0, rows - 1),  // start within canvas — overdraw trail builds from frame 1
+        streamLen:    streamLen,             // kept from streaming model; does not affect overdraw trail
+        emojiStream:  Math.random() < t.MATRIX_EMOJI_STREAM_CHANCE, // decided once at init, never re-rolled
         speedFactor:  speedFactor,
         charDelay:    Math.round(BASE_CHAR_DELAY_MS / speedFactor), // fixed for duration
         nextCharTime: Date.now() + t.rand(0, t.MATRIX_RAIN_STAGGER_MAX_MS),
@@ -399,11 +399,12 @@ window.APC.boot = (function () {
 
   // --- Matrix rain render loop -----------------------------------------
   //
-  // Column stream model: each column maintains a full visible stream of
-  // N characters (8–20) falling together as a unit. The head advances one
-  // row per tick; the trail follows above it, fading by position. Characters
-  // re-randomize every frame (flicker effect). clearRect replaces overdraw —
-  // all active cells are re-drawn explicitly each frame.
+  // Overdraw trail model: each frame, fill the canvas with a low-alpha black
+  // to gradually dim previous characters (phosphor glow effect). Then draw
+  // only the head character for each active column at full brightness. The
+  // visible comet trail is formed by the per-frame fade, not explicit position
+  // opacities. At MATRIX_TRAIL_OVERDRAW_ALPHA 0.05 (~60fps): a character
+  // fades to ~5% brightness after ~57 frames (~1s) — roughly 8 visible rows.
 
   function drawFrame() {
     const now = Date.now();
@@ -418,9 +419,10 @@ window.APC.boot = (function () {
     const rows = Math.floor(canvas.height / FONT_SIZE);
     const t = window.APC.timing;
 
-    // Clear full canvas each frame — streaming model re-draws all active cells explicitly.
-    // Replaces the old rgba(0,0,0,0.15) overdraw; canvas background shows through cleared cells.
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    // Per-frame overdraw — dims all previous content by MATRIX_TRAIL_OVERDRAW_ALPHA each frame.
+    // Lower alpha = longer visible trail (0.05 → ~57 frames before fading to 5% brightness).
+    ctx.fillStyle = 'rgba(0, 0, 0, ' + t.MATRIX_TRAIL_OVERDRAW_ALPHA + ')';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     ctx.font = FONT_SIZE + 'px "Courier New", monospace';
     ctx.fillStyle = MATRIX_COLOR;
@@ -443,55 +445,34 @@ window.APC.boot = (function () {
         col.nextCharTime = now + col.charDelay;
       }
 
-      // Stream fully exited — begin post-exit pause.
-      // Check tail (headRow - streamLen + 1) rather than head so the full stream clears.
-      if (col.headRow - col.streamLen + 1 >= rows) {
+      // Head fully exited — begin post-exit pause.
+      if (col.headRow >= rows) {
         col.active = false;
         col.pauseUntil = now + t.rand(t.MATRIX_RAIN_RESET_MIN_MS, t.MATRIX_RAIN_RESET_MAX_MS);
         continue;
       }
 
-      // Draw stream — head at headRow, trail going upward (j=0 is head).
-      // Characters re-randomize every frame for flicker effect.
-      for (let j = 0; j < col.streamLen; j++) {
-        const row = col.headRow - j;
-        if (row < 0 || row >= rows) { continue; }
+      if (col.headRow < 0) { continue; } // head still above canvas
 
-        let opacity;
-        if (j < TRAIL_OPACITIES.length) {
-          opacity = TRAIL_OPACITIES[j];
-        } else {
-          // Linear taper: 0.2 at TRAIL_OPACITIES.length → 0 at stream tail.
-          const tailLen = col.streamLen - TRAIL_OPACITIES.length;
-          opacity = tailLen > 0 ? 0.2 * (1 - (j - TRAIL_OPACITIES.length) / tailLen) : 0;
-        }
-        if (opacity <= 0) { continue; }
-
-        const y = (row + 1) * FONT_SIZE;
-        ctx.globalAlpha = opacity;
-
-        if (Math.random() < t.MATRIX_EMOJI_FREQUENCY) {
-          // 2% of characters are emoji — natural OS color, no filter applied.
-          ctx.fillText(
-            MATRIX_EMOJIS[Math.floor(Math.random() * MATRIX_EMOJIS.length)],
-            col.x, y
-          );
-        } else {
-          ctx.fillText(
-            MATRIX_CHARS[Math.floor(Math.random() * MATRIX_CHARS.length)],
-            col.x, y
-          );
-        }
+      // Draw head character at full brightness. Trail is formed by per-frame overdraw fade.
+      // emojiStream columns draw only emojis; all other columns draw only katakana/ASCII.
+      const y = (col.headRow + 1) * FONT_SIZE;
+      if (col.emojiStream) {
+        ctx.fillText(
+          MATRIX_EMOJIS[Math.floor(Math.random() * MATRIX_EMOJIS.length)],
+          col.x, y
+        );
+      } else {
+        ctx.fillText(
+          MATRIX_CHARS[Math.floor(Math.random() * MATRIX_CHARS.length)],
+          col.x, y
+        );
       }
     }
 
-    // Restore defaults before drawing identity lines.
-    ctx.globalAlpha = 1;
-    ctx.fillStyle = MATRIX_COLOR;
-
     // Redraw identity lines at full brightness each frame so they're always
-    // visible over the streaming rain. Y positions recalculate from canvas.height
-    // on each frame so a resize mid-sequence doesn't leave lines at stale positions.
+    // visible over the rain. Y positions recalculate from canvas.height on each
+    // frame so a resize mid-sequence doesn't leave lines at stale positions.
     if (identityPhase !== 'waiting' && identityTypedLines.length > 0) {
       const startY = canvas.height * t.MATRIX_IDENTITY_START_Y_PCT;
       const lineHeight = FONT_SIZE * 1.6;

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -62,7 +62,10 @@
     MATRIX_DURATION_MAX_MS:        12000,  // maximum rain duration
     MATRIX_COL_SPEED_MIN_PCT:       0.80,  // per-column speed floor (80% of base velocity)
     MATRIX_COL_SPEED_MAX_PCT:       1.00,  // per-column speed ceiling (100% of base velocity)
-    MATRIX_EMOJI_FREQUENCY:         0.02,  // 2% of all characters are emoji (natural color)
+    MATRIX_EMOJI_FREQUENCY:         0.02,  // superseded by emojiStream column model — kept for reference
+    MATRIX_EMOJI_STREAM_CHANCE:     0.01,  // 1% of columns are emoji-only; remaining 99% never produce emojis
+    MATRIX_TRAIL_OVERDRAW_ALPHA:    0.05,  // per-frame canvas fade alpha; lower = longer visible trail
+    MATRIX_STREAM_BASE_DELAY_MS:     125,  // base ms per head advance (was hardcoded 100 — 25% slower)
     MATRIX_STREAM_LEN_MIN:            15,  // min visible characters per column stream
     MATRIX_STREAM_LEN_MAX:            80,  // max — exceeds screen rows; tail clips naturally at canvas edge
     MATRIX_CURSOR_BLINK_MS:          530,  // terminal prompt cursor blink interval (matches CSS)


### PR DESCRIPTION
Closes #147

## Three changes

**1. Emoji-only streams**

1% of columns (`MATRIX_EMOJI_STREAM_CHANCE: 0.01`) are dedicated emoji-only. The `emojiStream` flag is set once per column in `initColumns()` and never re-rolled. `emojiStream: true` columns draw only emojis; all others draw only katakana/ASCII — no mixed-in emojis anywhere. `MATRIX_EMOJI_FREQUENCY` is retained in the token file for reference but no longer used in draw logic.

**2. Longer trail visibility — overdraw model**

Switched from `clearRect` + explicit `TRAIL_OPACITIES` (position-based opacity) to the overdraw model: each frame fills the canvas with `rgba(0, 0, 0, MATRIX_TRAIL_OVERDRAW_ALPHA)` before drawing. Only the **head character** is drawn per column; the comet trail is formed by previous frames fading.

At `MATRIX_TRAIL_OVERDRAW_ALPHA: 0.05` (~60fps): a character fades to ~5% brightness after ~57 frames (~1s) — roughly 8 visible rows of trail. `TRAIL_OPACITIES` constant removed (dead code).

Also fixed `headRow` initialization: was `-Math.floor(Math.random() * streamLen)` (0 to -79), which caused columns with large `streamLen` to miss short rain durations entirely. Changed to `t.rand(0, rows - 1)` — all columns start at visible positions from frame 1.

**3. 25% slower speed**

`BASE_CHAR_DELAY_MS` now reads `MATRIX_STREAM_BASE_DELAY_MS: 125` instead of the hardcoded `100`. Per-column charDelay range: 125–156ms (was 100–125ms).

## Files changed

| File | Change |
|------|--------|
| `js/win98-timing.js` | Add `MATRIX_EMOJI_STREAM_CHANCE: 0.01`, `MATRIX_TRAIL_OVERDRAW_ALPHA: 0.05`, `MATRIX_STREAM_BASE_DELAY_MS: 125`; update `MATRIX_EMOJI_FREQUENCY` comment |
| `js/boot.js` | Add `emojiStream` to column object; replace per-character emoji roll with `col.emojiStream`; switch `clearRect` → `fillRect` overdraw; draw head only (remove inner `for j` loop + `TRAIL_OPACITIES`); update exit condition; fix `headRow` init; tokenize `BASE_CHAR_DELAY_MS` |
| `js/CLAUDE.md` | Update column model, render model, emoji, speed sections |

## QA checklist

- [ ] ~1% of columns render emoji top-to-bottom — no katakana/ASCII mixed in
- [ ] Remaining ~99% of columns render katakana/ASCII only — no emojis
- [ ] Trail reads as visibly green for 8+ rows before fading
- [ ] Rain feels noticeably slower / more deliberate than before
- [ ] Rain fills the screen immediately (no sparse top half on load)
- [ ] Clicking/keypressing triggers wormhole correctly
- [ ] `restart()` replays clean rain — `emojiStream` re-rolled on `initColumns()`