### PR TITLE
feat: Matrix rain — MatrixCode font infrastructure (css/boot.css + js/CLAUDE.md only)

### DIFF
--- a/css/boot.css
+++ b/css/boot.css
@@ -1,3 +1,15 @@
+/* --- MatrixCode font — MIT licensed, self-hosted, approved exception to system-fonts-only rule.
+   Source: Rezmason/matrix (github.com/Rezmason/matrix), assets/Matrix-Code.ttf.
+   Used exclusively by boot.js canvas rain via ctx.font. Not used in HTML/CSS elements.
+   Do not apply to #gate-terminal or any HTML element — Courier New only for DOM text. --- */
+@font-face {
+  font-family: 'MatrixCode';
+  src: url('../assets/fonts/Matrix-Code.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}
+
 /* ============================================================
    boot.css — Gate screen styles (Matrix rain + Click to Start)
    Scope: #gate-screen and children only. No Win98 chrome here.

--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -295,6 +295,9 @@ Degrade to `'--'` on failure — never crash.
 - **New `ie-` prefixed files or classes** — wrong. Use `netescape-` prefix.
 - **Calling proxy APIs directly from client** — wrong. All API calls go through Caddy routes.
 - **Importing external fonts or icon libraries** — wrong. System fonts only, assets self-hosted.
+  Exception: `MatrixCode` (`assets/fonts/Matrix-Code.ttf`) is approved for Canvas rain use only.
+  It is MIT licensed (Rezmason/matrix), self-hosted on Pi, and declared in `css/boot.css` via `@font-face`.
+  Do NOT apply MatrixCode to any HTML element or CSS font-family stack — Canvas `ctx.font` only.
 - **`hddChatter.loop = false`** — wrong. Chatter must loop indefinitely.
 - **`fadeAudioOut(hddChatter, ...)`** — wrong. Chatter never stops; use `fadeAudioTo()` only.
 - **`setTimeout(() => hddChatter.play(), delay)`** — wrong. Blocked by browser autoplay policy.


### PR DESCRIPTION
Closes #149

Zero-behavior change. Purely additive infrastructure for the MatrixCode font, required before #150 can wire it to the canvas.

## What changed

**`css/boot.css`** — `@font-face` block added at the top of the file:
- `font-family: 'MatrixCode'`
- `src: url('../assets/fonts/Matrix-Code.ttf') format('truetype')`
- `font-display: block` — prevents fallback flash; the font-load gate in #150 ensures the canvas never draws until the font is ready
- Self-hosted, MIT licensed (Rezmason/matrix)

**`js/CLAUDE.md`** — Common Pitfalls entry updated to document MatrixCode as an approved `ctx.font`-only exception to the system-fonts-only rule.

## What did NOT change

- `boot.js` — untouched. Canvas still uses `'Courier New', monospace` until #150.
- `index.html`, `win98-timing.js`, `Caddyfile` — untouched.
- `#gate-terminal` font — unchanged (`Courier New`).
- CSP — `font-src` defaults to `'self'`; self-hosted TTF is compliant.

## Verification

- [ ] Network tab → hard refresh → `Matrix-Code.ttf` returns HTTP 200
- [ ] No visual change to the rain (still Courier New)
- [ ] No console errors (no 404 for the font file)

> The Fonts tab in DevTools may not show MatrixCode at this stage — that's expected. The font is declared but not yet used by any element or canvas context. HTTP 200 in Network is the correct verification.

## Blocks

#150 — boot.js font activation + font-load gate