### PR TITLE
feat: Matrix rain — activate MatrixCode font in boot.js canvas + font-load gate

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -257,6 +257,13 @@ window.APC.boot = (function () {
       }
     }
 
+    // Gate on MatrixCode font load before starting rain — prevents blank-glyph
+    // rendering on slow loads. .finally() ensures rain starts regardless of
+    // whether the font loaded successfully. Never block the boot experience on a font.
+    document.fonts.load(FONT_SIZE + 'px MatrixCode').finally(_startRain);
+  }
+
+  function _startRain() {
     // Roll rain duration once — stays fixed for this run.
     const t = window.APC.timing;
     rainDuration = t.MATRIX_DURATION_MIN_MS +
@@ -424,7 +431,7 @@ window.APC.boot = (function () {
     ctx.fillStyle = 'rgba(0, 0, 0, ' + t.MATRIX_TRAIL_OVERDRAW_ALPHA + ')';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    ctx.font = FONT_SIZE + 'px "Courier New", monospace';
+    ctx.font = FONT_SIZE + 'px MatrixCode, "Courier New", monospace';
     ctx.fillStyle = MATRIX_COLOR;
 
     for (let i = 0; i < columns.length; i++) {
@@ -469,6 +476,10 @@ window.APC.boot = (function () {
         );
       }
     }
+
+    // Identity lines render in Courier New — prose, not Matrix glyphs.
+    // Reset font explicitly so they are unaffected by the MatrixCode ctx.font above.
+    ctx.font = FONT_SIZE + 'px "Courier New", monospace';
 
     // Redraw identity lines at full brightness each frame so they're always
     // visible over the rain. Y positions recalculate from canvas.height on each
@@ -1388,7 +1399,7 @@ window.APC.boot = (function () {
       ctx.fillStyle   = '#000';
       ctx.fillRect(0, 0, w, h);
 
-      ctx.font      = FONT_SIZE + 'px "Courier New", monospace';
+      ctx.font      = FONT_SIZE + 'px MatrixCode, "Courier New", monospace';
       ctx.fillStyle = MATRIX_COLOR;
 
       var i, c, glowRadius;


### PR DESCRIPTION
Closes #150

## Summary

- `drawFrame`: `ctx.font` → `'MatrixCode, "Courier New", monospace'` for rain glyphs; Courier New fallback retained
- `drawFrame`: explicit `ctx.font` reset to Courier New before the identity lines block — prevents prose text from rendering in MatrixCode glyphs
- `wormFrame`: `ctx.font` → `'MatrixCode, "Courier New", monospace'` for wormhole characters
- `init()`: rain startup logic extracted to private `_startRain()`; `init()` now ends with `document.fonts.load(FONT_SIZE + 'px MatrixCode').finally(_startRain)` — gates rain on font readiness, always fires on failure too, never blocks the boot experience

## Depends on

#149 (MatrixCode `@font-face` in `css/boot.css` + `js/CLAUDE.md` documentation) must be merged first.

## Test plan

- [ ] Hard-refresh — Matrix rain characters render in MatrixCode glyph style (not Courier New box letters)
- [ ] Identity lines ("ATSUSHI HAMAMOTO", etc.) still render in Courier New — not MatrixCode glyphs
- [ ] Wormhole disturbance/spiral phases show MatrixCode glyphs
- [ ] `document.fonts.load()` failure (block the TTF in DevTools): rain starts after a short delay — no blank screen, no hang
- [ ] Rain starts with similar timing as before — no perceptible delay on subsequent visits (font cached by browser)
- [ ] `restart()` still works — rain reinitializes correctly
- [ ] No `_startRain` on `window.APC.boot` — private function, not exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)