### PR TITLE
feat: Matrix rain — Rezmason-inspired visual upgrades (cursor tip + trail depth + emoji isolation)

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -11,7 +11,8 @@ window.APC.boot = (function () {
 
   // --- Constants -------------------------------------------------------
 
-  const MATRIX_COLOR = '#00FF41';
+  const MATRIX_COLOR  = '#00FF41';
+  const CURSOR_COLOR  = '#CCFFCC'; // near-white head — Rezmason cursor tip color
   const FONT_SIZE = 14;
   // Emoji columns: 1% of columns are emoji-only (emojiStream flag set in initColumns).
   // The remaining 99% are katakana/ASCII only — no per-character emoji roll.
@@ -465,11 +466,20 @@ window.APC.boot = (function () {
       // emojiStream columns draw only emojis; all other columns draw only katakana/ASCII.
       const y = (col.headRow + 1) * FONT_SIZE;
       if (col.emojiStream) {
+        // Isolate emoji draw — ctx.save/restore prevents fillStyle state leakage
+        // in both directions. Emoji are color glyphs that ignore fillStyle on most
+        // browsers, but isolation is correct and defensive.
+        ctx.save();
         ctx.fillText(
           MATRIX_EMOJIS[Math.floor(Math.random() * MATRIX_EMOJIS.length)],
           col.x, y
         );
+        ctx.restore();
       } else {
+        // Every character drawn IS the head at this moment — col.headRow is always
+        // the leading cell. CURSOR_COLOR gives the bright tip; the phosphor trail
+        // behind it fades via per-frame overdraw.
+        ctx.fillStyle = CURSOR_COLOR;
         ctx.fillText(
           MATRIX_CHARS[Math.floor(Math.random() * MATRIX_CHARS.length)],
           col.x, y


### PR DESCRIPTION
Closes #151

## Summary

- **`CURSOR_COLOR = '#CCFFCC'`** — new constant (near-white); `MATRIX_COLOR '#00FF41'` unchanged
- **Cursor tip:** non-emoji branch in `drawFrame()` sets `ctx.fillStyle = CURSOR_COLOR` per draw — the head character renders bright white-green while the phosphor trail behind it fades naturally via per-frame overdraw (alpha stays at `0.05`, unchanged from PR #148)
- **Emoji isolation:** emoji branch wrapped in `ctx.save()` / `ctx.restore()` — prevents `fillStyle` state leakage in both directions; emoji are color glyphs that ignore `fillStyle` on most browsers anyway, but the isolation is correct and defensive

## What did NOT change

- `MATRIX_COLOR` (`#00FF41`) — still used for identity lines; those `ctx.fillStyle` assignments are untouched
- Overdraw alpha (`0.05`) — verified, not touched
- `wormFrame()` — unchanged
- All timing tokens — unchanged
- `MATRIX_CHARS`, `MATRIX_EMOJIS`, `emojiStream` column logic — unchanged

## Test plan

- [ ] Rain head characters visibly brighter/whiter than the trail behind them
- [ ] Trail remains visible and deep — ~20 rows fading (overdraw alpha `0.05`)
- [ ] Emoji appear in full natural color, no green tinting artifact
- [ ] Identity lines (`> ATSUSHI HAMAMOTO` etc.) remain flat `#00FF41` — not whitened
- [ ] Wormhole animation characters are unaffected (green, no cursor tip color)
- [ ] No console errors
- [ ] Soft restart replays correctly with all visual upgrades intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)