### PR TITLE
fix: orphaned timer leak, deploy idempotency, lifecycle docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@ Browser-based Win98 desktop simulation and personal PM portfolio hosted on Raspb
 3. Never install packages, dependencies, or build tooling. Zero exceptions.
 4. Never deviate from any rule without explicitly asking first.
 5. After every task, summarize changes and flag anything needing manual QA.
+6. **Pre-Flight Architecture Check** — Before writing any code that introduces new state, timers, loops, or DOM elements, explicitly answer:
+   - How will this feature be destroyed? (Detail the exact cleanup path.)
+   - What happens if the user restarts mid-execution?
+   - Does this introduce a new z-index, and if so, where does it sit in the global hierarchy?
 
 ---
 
@@ -23,6 +27,29 @@ Browser-based Win98 desktop simulation and personal PM portfolio hosted on Raspb
 - **No external CDN calls** in production. Umami and the Altcha widget are the only exceptions.
 - **Never commit `.env`.** Only `.env.example` is versioned.
 - **Never modify** `assets/CREDITS.md`, `.env.example`, or `config/Caddyfile` without being explicitly asked.
+
+---
+
+## Memory & Lifecycle Integrity
+
+These rules are as non-negotiable as the no-framework rule. Violations cause memory leaks and silent timer ghosts that survive across soft restarts.
+
+**No orphaned timers.** Every `setInterval` and `setTimeout` return value MUST be assigned to a named variable. Inline-fire-and-forget timers are forbidden.
+
+**Mandatory teardown.** Every module, mini-app, or window MUST expose a `close()`, `stop()`, or `reset()` method. That method MUST explicitly `clearInterval` / `clearTimeout` / `cancelAnimationFrame` every timer or loop the module owns. No exceptions, even for "simple" apps.
+
+**DOM presence guard on recursive loops.** Any `requestAnimationFrame` or chained `setTimeout` loop MUST check that its target element is still in the document before executing the next tick:
+```js
+// WRONG
+function tick() { el.textContent = '...'; requestAnimationFrame(tick); }
+
+// RIGHT
+function tick() { if (!el.parentNode) { return; } el.textContent = '...'; requestAnimationFrame(tick); }
+```
+
+**Singleton state must be nulled on close.** If a module tracks a singleton (e.g. `winState`, `isOpen`), `close()` MUST reset that flag. Otherwise a restart leaves the module believing the window is still open.
+
+**`desktop.reset()` is the canonical teardown caller.** It calls `closeAll()` then iterates `window.APC.apps` and calls `.close()` on any app that exposes it. Any new app that owns timers MUST expose `close()` so `reset()` can reach it.
 
 ---
 

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -113,6 +113,30 @@ Git remotes on Pi:
 
 ---
 
+## Python Service Rules
+
+**Every in-process memory structure that grows over time MUST have an active cleanup mechanism.**
+
+This means rate limiters, token buckets, request counters, and any per-IP or per-key tracker MUST:
+1. Implement a `cleanup()` method that evicts stale entries (e.g. entries not touched in N seconds).
+2. Call `cleanup()` on a recurring daemon thread or within the request handler before writing new entries.
+3. Never rely on process restart as the GC strategy — services are long-running.
+
+The `RateLimiter` class in all three proxy servers (`ram-server.py`, `weather-server.py`, `altcha-server.py`) already implements this pattern. New services must replicate it. Existing services must not remove it.
+
+```python
+# Required pattern for any in-memory per-key tracker
+def cleanup(self):
+    cutoff = time.time() - self.window_seconds * 2
+    stale = [k for k, v in self._store.items() if v['last_seen'] < cutoff]
+    for k in stale:
+        del self._store[k]
+```
+
+**No unbounded dict growth.** If a dict is keyed by user input (IP, URL, token), it MUST have a cleanup path. A dict that only grows is a DoS vector and a memory leak.
+
+---
+
 ## Cloudflare RUM — Intentionally Disabled
 
 Cloudflare automatically injects a Real User Monitoring (RUM) beacon script

--- a/css/CLAUDE.md
+++ b/css/CLAUDE.md
@@ -13,6 +13,19 @@ These rules are absolute. Breaking them breaks the simulation.
 - **No modern layout** (flexbox/grid) for Win98 chrome. Use tables, `position: absolute`, floats.
   Exception: NetEscape page content may use modern CSS inside the browser content area.
 - **Tight spacing.** 2–4px gaps. No modern whitespace.
+- **No hardcoded z-indexes in JS.** Layering is owned by CSS. New z-index values belong in `win98.css` as named classes, not inline `style.zIndex = 9999` in scripts.
+  The established hierarchy (do not insert between layers without explicit review):
+
+  | Layer | Value | Owner |
+  |---|---|---|
+  | Desktop icons | 1 | CSS default |
+  | Windows (dynamic) | 100–∞ | `desktop.js` `zCounter` |
+  | Disk Cleanup window | 3000 | `diskcleanup.js` (exception: self-managed) |
+  | Tray balloon (behind glitch) | 998 | `widgets.js` |
+  | Taskbar | 1000 | CSS |
+  | Start menu | 2000 | CSS |
+  | Wireframe drag animation | 99999 | `desktop.js` (transient) |
+  | Modal overlays | 10000 | CSS `.win98-msgbox-overlay` |
 
 ---
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,6 +5,7 @@ echo "[deploy] ensuring emoji font is installed..."
 sudo apt-get install -y fonts-noto-color-emoji 2>/dev/null | tail -1
 
 echo "[deploy] pulling latest from main..."
+git checkout -- index.html
 git pull origin main
 
 echo "[deploy] building css bundle..."
@@ -49,7 +50,8 @@ start = content.find(marker_start)
 end = content.find(marker_end)
 
 if start == -1 or end == -1:
-    print('[deploy] WARNING: CSS markers not found — index.html unchanged')
+    print('[deploy] ERROR: CSS markers not found in index.html — patch failed')
+    import sys; sys.exit(1)
 else:
     end_pos = end + len(marker_end)
     patched = content[:start] + bundle_link + content[end_pos:]

--- a/js/apps/CLAUDE.md
+++ b/js/apps/CLAUDE.md
@@ -22,6 +22,50 @@ On complete: `cursor: default` restored, window mounts, brought to front.
 
 ---
 
+## Standard App Interface Contract
+
+Every mini-app MUST return an object with the following hooks. Missing any hook is a bug.
+
+| Hook | Required | Responsibility |
+|---|---|---|
+| `open()` | Yes | Launch or focus existing singleton window |
+| `close()` | Yes | Clear ALL timers/intervals/rAF loops, null singleton refs, remove any self-managed DOM |
+| `pause()` | If rAF loop present | Cancel the rAF loop without destroying state — called when window is minimized |
+| `resume()` | If `pause()` exists | Restart the rAF loop — called on restore |
+
+**`close()` is the contract with `desktop.reset()`.** `reset()` iterates `window.APC.apps` and calls `.close()` on any app that exposes it. If your app owns timers but doesn't expose `close()`, those timers will outlive a soft restart.
+
+**Apps that manage their own DOM** (i.e. append directly to `document.body` instead of going through `desktop.createWindow`) MUST remove that DOM in `close()`. `windowLayer.innerHTML = ''` will not reach it.
+
+**Singleton flags** (`isOpen`, `winState`, etc.) MUST be reset inside `close()`. Failing to do so leaves the module believing the window is still open after restart.
+
+```js
+// Minimum viable app scaffold
+window.APC.apps.myApp = (function () {
+  'use strict';
+  var winState = null;
+  var tickTimer = null;
+
+  function close() {
+    if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+    winState = null;
+    // If self-managed DOM: var el = document.getElementById('myapp-window'); if (el) el.remove();
+  }
+
+  function open() {
+    if (winState) { /* focus existing */ return; }
+    winState = window.APC.desktop.createWindow({ ... });
+    winState.el.querySelector('[data-action="close"]').addEventListener('click', close);
+    tickTimer = setInterval(tick, 1000);
+    winState.show();
+  }
+
+  return { open: open, close: close };
+}());
+```
+
+---
+
 ## Disk Cleanup (js/apps/diskcleanup.js)
 
 **Interface:** `window.APC.apps.diskcleanup = { open() }`

--- a/js/apps/diskcleanup.js
+++ b/js/apps/diskcleanup.js
@@ -285,7 +285,8 @@ if (!window.APC?.timing) throw new Error('[APC] win98-timing.js must load before
       }
       isOpen = true;
       buildWindow();
-    }
+    },
+    close: close
   };
 
 }());

--- a/js/apps/minesweeper.js
+++ b/js/apps/minesweeper.js
@@ -15,6 +15,12 @@ window.APC.apps.minesweeper = (function () {
   const MINES = 10;
 
   let winState = null;
+  let timerInterval = null; // hoisted for teardown access from close()
+
+  function close() {
+    if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
+    winState = null;
+  }
 
   function open() {
     if (winState) {
@@ -56,7 +62,6 @@ window.APC.apps.minesweeper = (function () {
     var gameState = 'idle'; // 'idle' | 'playing' | 'won' | 'lost'
     var minesLeft = MINES;
     var timerVal = 0;
-    var timerInterval = null;
     var firstClick = true;
 
     // DOM refs set during build
@@ -495,6 +500,6 @@ window.APC.apps.minesweeper = (function () {
     renderAll();
   }
 
-  return { open: open };
+  return { open: open, close: close };
 
 }());

--- a/js/desktop.js
+++ b/js/desktop.js
@@ -1419,7 +1419,15 @@ window.APC.desktop = (function () {
   // --- Module reset (called by boot.restart()) -------------------------
 
   function reset() {
-    Object.keys(windows).forEach(function (id) { delete windows[id]; });
+    closeAll();
+    // Tear down any app that exposes a close() method (e.g. diskcleanup, minesweeper).
+    // This cancels in-flight timers and resets singleton flags before the DOM is wiped.
+    if (window.APC.apps) {
+      Object.keys(window.APC.apps).forEach(function (appName) {
+        var app = window.APC.apps[appName];
+        if (app && typeof app.close === 'function') { app.close(); }
+      });
+    }
     Object.keys(iconLastClick).forEach(function (k) { delete iconLastClick[k]; });
     Object.keys(appLaunching).forEach(function (k) { clearTimeout(appLaunching[k]); delete appLaunching[k]; });
     // Cancel all pending icon hint timers before clearing state.


### PR DESCRIPTION
## Summary

- Fixes soft-restart orphaned timer leak in `diskcleanup.js` and `minesweeper.js` (#182)
- Fixes `deploy.sh` idempotency failure on second run (#183)
- Adds Memory & Lifecycle Integrity documentation layer across all CLAUDE.md files (#184)

## Changes

### Bug fixes

**`js/desktop.js` — `reset()`**
Replaced raw `delete windows[id]` with `closeAll()` (proper `closeWindow()` path for all registered windows) followed by an app teardown loop that calls `.close()` on any `window.APC.apps` entry that exposes it.

**`js/apps/diskcleanup.js`**
Exposed the existing private `close()` on the public API. Clears all 4 timers, removes self-managed DOM from `document.body`, resets `isOpen`.

**`js/apps/minesweeper.js`**
Hoisted `timerInterval` to module scope. Added `close()` that clears the interval and nulls `winState`. Exposed on public API.

**`deploy.sh`**
Added `git checkout -- index.html` before `git pull` so every deploy starts from a clean working tree. Promoted silent `WARNING` to `sys.exit(1)` so a missing CSS marker aborts before Caddy reloads.

### Documentation

**`CLAUDE.md`** — Memory & Lifecycle Integrity section (5 rules) + Pre-Flight Architecture Check (item 6 under Before Every Task)

**`js/apps/CLAUDE.md`** — Standard App Interface Contract: required hooks table, self-managed DOM rules, scaffold example

**`css/CLAUDE.md`** — z-index layer hierarchy table, no-hardcoded-z-index-in-JS rule

**`config/CLAUDE.md`** — Python Service Rules: `cleanup()` requirement, no unbounded dict growth

## Test plan

- [ ] Open Minesweeper, start game (timer running) → Restart → reopen Minesweeper — timer starts at 000
- [ ] Open Disk Cleanup mid-scan → Restart — window gone, no orphaned timer activity
- [ ] Normal X-button close on both apps still works
- [ ] Restart with no apps open — no errors
- [ ] SSH to Pi, run `~/deploy.sh` twice back-to-back — both complete, both print `index.html patched`

Closes #182
Closes #183
Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)