### PR TITLE
fix: call RateLimiter.cleanup() on every is_allowed() in all three servers

### DIFF
--- a/config/altcha-server.py
+++ b/config/altcha-server.py
@@ -33,6 +33,7 @@ class RateLimiter:
         self._lock = threading.Lock()
 
     def is_allowed(self, ip):
+        self.cleanup()
         now = time.time()
         with self._lock:
             if ip not in self._buckets:

--- a/config/ram-server.py
+++ b/config/ram-server.py
@@ -14,6 +14,7 @@ class RateLimiter:
         self._lock = threading.Lock()
 
     def is_allowed(self, ip):
+        self.cleanup()
         now = time.time()
         with self._lock:
             if ip not in self._buckets:

--- a/config/weather-server.py
+++ b/config/weather-server.py
@@ -28,6 +28,7 @@ class RateLimiter:
         self._lock = threading.Lock()
 
     def is_allowed(self, ip):
+        self.cleanup()
         now = time.time()
         with self._lock:
             if ip not in self._buckets:


### PR DESCRIPTION
## Summary

Adds `self.cleanup()` as the first line of `is_allowed()` in all three Python proxy servers, activating the stale-bucket eviction that was already implemented but never called.

Closes #186

## Changes

`config/ram-server.py`, `config/altcha-server.py`, `config/weather-server.py` — identical one-line fix in each:

```python
def is_allowed(self, ip):
    self.cleanup()          # ← added
    now = time.time()
    with self._lock:
```

`cleanup()` evicts any bucket whose `last` timestamp is older than `window_seconds * 2`, bounding `_buckets` to only IPs active within the current rate-limit window.

## Test plan

- [ ] After syncing to Pi, confirm services restart cleanly: `sudo systemctl restart ram-server weather-server altcha-server`
- [ ] Confirm `/ram` and `/weather` still respond after restart

## Deploy note

These are `config/` reference copies. After merging, sync to Pi:
```bash
scp config/ram-server.py atsushispc:~/ram-server.py
scp config/altcha-server.py atsushispc:~/altcha-server.py
scp config/weather-server.py atsushispc:~/weather-server.py
ssh atsushispc 'sudo systemctl restart ram-server weather-server altcha-server'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)