### PR TITLE
fix: remove MutationObserver from attachNestedSubmenuHover

### DIFF
--- a/js/taskbar.js
+++ b/js/taskbar.js
@@ -342,14 +342,6 @@ window.APC.taskbar = (function () {
       closeTimer = setTimeout(function () { closeTimer = null; closeNested(); }, t.SUBMENU_CLOSE_DELAY_MS);
     });
 
-    var parentSub = itemEl.parentNode;
-    if (parentSub) {
-      var mo = new MutationObserver(function () {
-        if (!parentSub.classList.contains('start-menu__submenu--open')) { closeNested(); }
-      });
-      mo.observe(parentSub, { attributes: true, attributeFilter: ['class'] });
-    }
-
     itemEl.addEventListener('keydown', function (e) {
       if (e.key === 'ArrowRight') {
         e.preventDefault(); openNested();


### PR DESCRIPTION
## Summary

Removes the `MutationObserver` block from `attachNestedSubmenuHover` in `taskbar.js` that was causing the nested submenu stack to collapse aggressively during hover navigation.

Closes #188

## What was removed

```js
var parentSub = itemEl.parentNode;
if (parentSub) {
  var mo = new MutationObserver(function () {
    if (!parentSub.classList.contains('start-menu__submenu--open')) { closeNested(); }
  });
  mo.observe(parentSub, { attributes: true, attributeFilter: ['class'] });
}
```

## Why it was wrong

The observer fired `closeNested()` any time the parent submenu lost the `--open` class — including transient class changes during sibling hover transitions. This collapsed the entire nested stack even when the mouse remained within the menu hierarchy.

`attachNestedSubmenuHover` already uses isolated per-node `openTimer`/`closeTimer` pairs driven by `mouseenter`/`mouseleave` events. Those timers are the correct and sufficient mechanism. The observer was a redundant second close trigger that fought against the timer isolation.

This was the known open bug documented in `CLAUDE.md`: "nested folder hover still collapses menu stack in some paths."

## Test plan

- [ ] Start > Programs > Accessories — hover into Accessories submenu, then into a nested app without the stack collapsing
- [ ] Moving mouse back out of a submenu still closes it correctly via the timer path
- [ ] Keyboard nav (ArrowRight/ArrowLeft/Escape) still works on nested items

🤖 Generated with [Claude Code](https://claude.com/claude-code)