### PR TITLE
fix: make deploy.sh CSS patch idempotent via regex dual-match

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -39,25 +39,38 @@ PYEOF
 
 echo "[deploy] patching index.html for production..."
 python3 << 'PYEOF'
+import re, sys
+
 with open('index.html', 'r') as f:
     content = f.read()
 
-marker_start = '  <!-- ============================================================\n       STYLESHEETS'
-marker_end = '  <link rel="stylesheet" href="css/minesweeper.css">'
 bundle_link = '  <!-- PRODUCTION: bundled CSS (built by deploy.sh, not in git) -->\n  <link rel="stylesheet" href="dist/bundle.css">'
 
-start = content.find(marker_start)
-end = content.find(marker_end)
+# Match either the original CSS comment block (first deploy) or the already-deployed
+# production comment (re-deploy). Makes the patch idempotent regardless of file state.
+match_start = re.search(
+    r'  <!-- ={10,}[\s\S]*?STYLESHEETS|  <!-- PRODUCTION: bundled CSS',
+    content
+)
 
-if start == -1 or end == -1:
+# Match either the original last CSS link (first deploy) or the already-deployed
+# bundle link (re-deploy).
+match_end = re.search(
+    r'  <link rel="stylesheet" href="css/minesweeper\.css">|  <link rel="stylesheet" href="dist/bundle\.css">',
+    content
+)
+
+if not match_start or not match_end:
     print('[deploy] ERROR: CSS markers not found in index.html — patch failed')
-    import sys; sys.exit(1)
-else:
-    end_pos = end + len(marker_end)
-    patched = content[:start] + bundle_link + content[end_pos:]
-    with open('index.html', 'w') as f:
-        f.write(patched)
-    print('[deploy] index.html patched — serving dist/bundle.css')
+    sys.exit(1)
+
+start   = match_start.start()
+end_pos = match_end.end()
+patched = content[:start] + bundle_link + content[end_pos:]
+
+with open('index.html', 'w') as f:
+    f.write(patched)
+print('[deploy] index.html patched — serving dist/bundle.css')
 PYEOF
 
 echo "[deploy] reloading caddy..."


### PR DESCRIPTION
## Summary

Replaces the fragile `str.find()` exact-string markers in the `index.html` patching step with `re.search()` patterns that match **either** the original dev state **or** the already-patched production state.

Closes #191

## What changed

**Before** — two exact `str.find()` calls that only match the original file:
```python
marker_start = '  <!-- ===...STYLESHEETS'
marker_end   = '  <link rel="stylesheet" href="css/minesweeper.css">'
start = content.find(marker_start)   # -1 if already patched
end   = content.find(marker_end)     # -1 if already patched
```

**After** — two `re.search()` calls with OR patterns covering both states:
```python
match_start = re.search(
    r'  <!-- ={10,}[\s\S]*?STYLESHEETS|  <!-- PRODUCTION: bundled CSS',
    content
)
match_end = re.search(
    r'  <link rel="stylesheet" href="css/minesweeper\.css">|  <link rel="stylesheet" href="dist/bundle\.css">',
    content
)
```

`match_end.end()` replaces the manual `end + len(marker_end)` — the match object already knows its own end position, which is correct for both variants.

## Idempotency matrix

| `index.html` state | `match_start` finds | `match_end` finds | Result |
|---|---|---|---|
| Fresh from git | original comment block | `minesweeper.css` link | ✅ patches correctly |
| Already deployed | `PRODUCTION:` comment | `bundle.css` link | ✅ re-patches to same output |
| Corrupt / unknown | no match | no match | ✅ exits 1, deploy aborts |

## Deploy note

`deploy.sh` lives at `~/deploy.sh` on the Pi, outside the git repo. Sync after merge:
```bash
scp deploy.sh atsushispc:~/deploy.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)