### PR TITLE
fix: isMobileOrTouch() OR-gate large-screen tablets correctly

### DIFF
--- a/js/boot.js
+++ b/js/boot.js
@@ -117,14 +117,12 @@ window.APC.boot = (function () {
   // --- Mobile detection ------------------------------------------------
   //
   // All three conditions must be true to show the mobile interstitial:
-  // 1. Genuine touch hardware (maxTouchPoints > 1)
-  // 2. Physically small screen (screen.width < 1024)
-  // 3. No fine pointer (no mouse/trackpad)
+  // Blocked if: touch hardware (maxTouchPoints > 1) AND (small screen OR no fine pointer)
+  // OR-grouping means a 12.9" iPad Pro (width > 1024 but no mouse) is still blocked.
 
   function isMobileOrTouch() {
     return navigator.maxTouchPoints > 1 &&
-           screen.width < 1024 &&
-           !window.matchMedia('(pointer: fine)').matches;
+           (screen.width < 1024 || !window.matchMedia('(pointer: fine)').matches);
   }
 
   function showMobileInterstitial() {


### PR DESCRIPTION
## Summary

One operator change: `&&` → `||` within the parenthesised width+pointer group.

Closes #193

## Change

```js
// BEFORE — triple AND; iPad Pro (width 1366) short-circuits at screen.width < 1024
return navigator.maxTouchPoints > 1 &&
       screen.width < 1024 &&
       !window.matchMedia('(pointer: fine)').matches;

// AFTER — touch hardware AND (small screen OR no fine pointer)
return navigator.maxTouchPoints > 1 &&
       (screen.width < 1024 || !window.matchMedia('(pointer: fine)').matches);
```

## Logic

| Device | `maxTouchPoints > 1` | `width < 1024` | `no fine pointer` | Before | After |
|---|---|---|---|---|---|
| iPhone 15 | ✅ | ✅ | ✅ | blocked ✅ | blocked ✅ |
| iPad Pro 12.9" (no keyboard) | ✅ | ❌ | ✅ | **bypassed ❌** | blocked ✅ |
| iPad Pro 12.9" + Magic Keyboard | ✅ | ❌ | ❌ | bypassed ❌ | bypassed ✅ |
| Desktop touchscreen (Surface Studio) | ✅ | ❌ | ❌ | bypassed ❌ | bypassed ✅ |
| Desktop (no touch) | ❌ | — | — | allowed ✅ | allowed ✅ |

Also updated the inline comment to document the OR semantics and the iPad Pro case explicitly.

## Test plan

- [ ] iPhone — mobile interstitial shown
- [ ] iPad Pro (no paired keyboard) — mobile interstitial shown
- [ ] Desktop — boots normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)