### PR TITLE
feat: NetEscape Curated Destinations

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,26 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Atsushi's PC</title>
-
-  <!-- ============================================================
-       STYLESHEETS
-       win98.css first — defines base Win98 shell variables + resets.
-       App-specific sheets follow in load order.
-  ============================================================ -->
   <link rel="stylesheet" href="css/win98.css">
-  <link rel="stylesheet" href="css/netescape-base.css">
-  <link rel="stylesheet" href="css/netescape-home.css">
-  <link rel="stylesheet" href="css/netescape-about.css">
-  <link rel="stylesheet" href="css/netescape-thoughts.css">
-  <link rel="stylesheet" href="css/netescape-projects.css">
-  <link rel="stylesheet" href="css/netescape-guestbook.css">
-  <link rel="stylesheet" href="css/netescape-resume.css">
   <link rel="stylesheet" href="css/boot.css">
-  <link rel="stylesheet" href="css/winamp.css">
-  <link rel="stylesheet" href="css/minesweeper.css">
-
-  <!-- Umami analytics — production only, no tracking in dev -->
-  <script defer src="https://cloud.umami.is/script.js" data-website-id="3a3a0d9e-3a74-44f6-819e-e30db61a8d1a"></script>
+  <link rel="stylesheet" href="css/desktop.css">
+  <link rel="stylesheet" href="css/netescape.css">
+  <link rel="stylesheet" href="css/dialup.css">
+  <link rel="stylesheet" href="css/taskbar.css">
+  <link rel="stylesheet" href="css/widgets.css">
 </head>
 <body>
 
@@ -42,10 +29,10 @@
     <div id="boot-progress-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="Windows 98 loading progress"></div>
   </div>
 
-  <!-- Five-screen boot sequence — POST, IBS Splash, DOS Log, WinDoors Logo, Desktop Arrival -->
+  <!-- Five-screen boot sequence -- POST, IBS Splash, DOS Log, WinDoors Logo, Desktop Arrival -->
   <div id="boot-sequence" class="boot-sequence--hidden" role="status" aria-live="polite" aria-label="System boot sequence"></div>
 
-  <!-- Desktop shell — shown after boot sequence completes -->
+  <!-- Desktop shell -- shown after boot sequence completes -->
   <div id="desktop" class="desktop--hidden">
 
     <!-- Desktop icons -->
@@ -60,7 +47,7 @@
       </div>
       <div class="desktop-icon" data-app="dialup" tabindex="0" role="button" aria-label="Dial-Up Networking">
         <span class="desktop-icon__img" aria-hidden="true">📞</span>
-        <span class="desktop-icon__label">Dial-Up Networking</span>
+ proporciona        <span class="desktop-icon__label">Dial-Up Networking</span>
       </div>
       <div class="desktop-icon" data-app="resume-exe" tabindex="0" role="button" aria-label="resume_FINAL_v3.exe">
         <span class="desktop-icon__img" aria-hidden="true">💾</span>
@@ -72,10 +59,10 @@
       </div>
     </div>
 
-    <!-- Window layer — windows are appended here by desktop.js -->
+    <!-- Window layer -- windows are appended here by desktop.js -->
     <div id="window-layer"></div>
 
-    <!-- Start menu — content built by taskbar.js on init() -->
+    <!-- Start menu -- content built by taskbar.js on init() -->
     <div id="start-menu" role="menu" aria-label="Start menu"></div>
 
     <!-- Taskbar: start button (float left), system tray (float right),
@@ -94,23 +81,24 @@
 
   </div>
 
-  <!-- Scripts — load order is strict. See CLAUDE.md. -->
+  <!-- Scripts -- load order is strict. See CLAUDE.md. -->
   <!-- win98-timing.js MUST be first. -->
   <script src="js/win98-timing.js"></script>
   <script src="js/boot-scene.js"></script>
   <script src="js/boot.js"></script>
   <script src="js/desktop.js"></script>
   <script src="js/taskbar.js"></script>
-  <script src="js/netescape.js"></script>
   <script src="js/widgets.js"></script>
-  <script src="js/winamp.js"></script>
-  <script src="js/notepad.js"></script>
-  <script src="js/minesweeper.js"></script>
-  <script src="js/diskcleanup.js"></script>
-  <script src="js/screensaver.js"></script>
-  <script src="js/system-properties.js"></script>
+  <script src="js/apps/calculator.js"></script>
+  <script src="js/apps/minesweeper.js"></script>
+  <script src="js/apps/notepad.js"></script>
+  <script src="js/apps/screensaver.js"></script>
+  <script src="js/apps/system-properties.js"></script>
+  <script src="js/apps/winamp.js"></script>
+  <script src="js/apps/diskcleanup.js"></script>
   <script src="js/phonedialer.js"></script>
-  <script src="js/main.js"></script>
+  <script src="js/netescape.js"></script>
+  <script src="js/apps/netescape-destinations.js"></script>
 
 </body>
 </html>

--- a/js/apps/netescape-destinations.js
+++ b/js/apps/netescape-destinations.js
@@ -1,0 +1,445 @@
+if (!window.APC || !window.APC.timing) throw new Error('[APC] win98-timing.js must load before netescape-destinations.js');
+// js/apps/netescape-destinations.js
+// NetEscape Curated Destinations — canvas scan-reveal of 2001-era Wayback screenshots.
+//
+// Exports: window.APC.neDestinations = { isDestination, render, cleanup }
+//
+// Integration point: netescape.js navigate() calls isDestination(normalized) after
+// the isConnected check and before renderPartialLoad(). If true, calls render(normalized)
+// and returns early. No other changes to netescape.js.
+//
+// All timing values come from window.APC.timing.DESTINATIONS_* tokens.
+// Never hardcode ms values here.
+
+(function () {
+  'use strict';
+
+  // ---------------------------------------------------------------------------
+  // DESTINATIONS map — single source of truth.
+  // To add or remove a destination, edit only this object.
+  // Keys are normalized URLs (no protocol, no www., no trailing slash).
+  // screenshot: path relative to site root, or null for Napster special case.
+  // folder: 'games' | 'cartoons' | 'sports' | 'cool-stuff' | null (root level)
+  // ---------------------------------------------------------------------------
+
+  var DESTINATIONS = {
+    // Games
+    'miniclip.com': {
+      label: 'Miniclip',
+      screenshot: 'assets/destinations/miniclip.jpg',
+      folder: 'games'
+    },
+    'ebaumsworld.com': {
+      label: "eBaum's World",
+      screenshot: 'assets/destinations/ebaumsworld.jpg',
+      folder: 'games'
+    },
+    'games.com': {
+      label: 'Games.com',
+      screenshot: 'assets/destinations/games.jpg',
+      folder: 'games'
+    },
+    'shockwave.com': {
+      label: 'Shockwave',
+      screenshot: 'assets/destinations/shockwave.jpg',
+      folder: 'games'
+    },
+    'addictinggames.com': {
+      label: 'AddictingGames',
+      screenshot: 'assets/destinations/addictinggames.jpg',
+      folder: 'games'
+    },
+    'neopets.com': {
+      label: 'Neopets',
+      screenshot: 'assets/destinations/neopets.jpg',
+      folder: 'games'
+    },
+    // Cartoons
+    'cartoonnetwork.com': {
+      label: 'Cartoon Network',
+      screenshot: 'assets/destinations/cartoonnetwork.jpg',
+      folder: 'cartoons'
+    },
+    'nick.com': {
+      label: 'Nick.com',
+      screenshot: 'assets/destinations/nick.jpg',
+      folder: 'cartoons'
+    },
+    'adultswim.com': {
+      label: 'Adult Swim',
+      screenshot: 'assets/destinations/adultswim.jpg',
+      folder: 'cartoons'
+    },
+    // Sports
+    'sports.yahoo.com': {
+      label: 'Yahoo Sports',
+      screenshot: 'assets/destinations/yahoo-sports.jpg',
+      folder: 'sports'
+    },
+    'basketball.fantasysports.yahoo.com': {
+      label: 'Yahoo Fantasy Basketball',
+      screenshot: 'assets/destinations/yahoo-fantasy-basketball.jpg',
+      folder: 'sports'
+    },
+    'nba.com': {
+      label: 'NBA.com',
+      screenshot: 'assets/destinations/nba.jpg',
+      folder: 'sports'
+    },
+    'trailblazers.com': {
+      label: 'Trail Blazers',
+      screenshot: 'assets/destinations/trailblazers.jpg',
+      folder: 'sports'
+    },
+    // Cool Stuff
+    'toysrus.com': {
+      label: 'Toys"R"Us',
+      screenshot: 'assets/destinations/toysrus.jpg',
+      folder: 'cool-stuff'
+    },
+    'blockbuster.com': {
+      label: 'Blockbuster',
+      screenshot: 'assets/destinations/blockbuster.jpg',
+      folder: 'cool-stuff'
+    },
+    // Root (no folder)
+    'yahooligans.com': {
+      label: 'Yahooligans',
+      screenshot: 'assets/destinations/yahooligans.jpg',
+      folder: null
+    },
+    'ask.com': {
+      label: 'Ask Jeeves',
+      screenshot: 'assets/destinations/ask.jpg',
+      folder: null
+    },
+    // Napster — special case. No screenshot, no audio, no canvas.
+    // White page with verbatim July 2001 RIAA court shutdown notice.
+    'napster.com': {
+      label: 'Napster',
+      screenshot: null,
+      folder: null
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Module-level state
+  // revealTimer: the setInterval handle for scan-reveal; must be cleared in cleanup().
+  // clickListener: the canvas click handler; stored so it can be removed on cleanup.
+  // ---------------------------------------------------------------------------
+
+  var revealTimer = null;
+  var clickListener = null;
+  var activeCanvas = null;  // the canvas currently in pageEl, if any
+
+  // Modem handshake audio — preloaded once at module init.
+  // Same pattern as dialupAudio in netescape.js.
+  // .play() is only called inside render(), after a user gesture has occurred.
+  var modemAudio = new Audio('assets/audio/modem-handshake.mp3');
+  modemAudio.preload = 'auto';
+  modemAudio.addEventListener('error', function () {});
+
+  // ---------------------------------------------------------------------------
+  // cleanup() — cancel any in-flight reveal, stop audio, remove canvas.
+  // Called by netescape.js navigate() before any new render begins.
+  // Must be idempotent — safe to call when nothing is active.
+  // ---------------------------------------------------------------------------
+
+  function cleanup() {
+    if (revealTimer !== null) {
+      clearInterval(revealTimer);
+      revealTimer = null;
+    }
+    if (modemAudio) {
+      modemAudio.pause();
+      modemAudio.currentTime = 0;
+    }
+    if (activeCanvas && clickListener) {
+      activeCanvas.removeEventListener('click', clickListener);
+      clickListener = null;
+    }
+    activeCanvas = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // isDestination(normalized) — returns true if the URL is in DESTINATIONS.
+  // ---------------------------------------------------------------------------
+
+  function isDestination(normalized) {
+    return Object.prototype.hasOwnProperty.call(DESTINATIONS, normalized);
+  }
+
+  // ---------------------------------------------------------------------------
+  // render(normalized) — main entry point called by netescape.js navigate().
+  // Handles both Napster special case and standard canvas scan-reveal.
+  // ---------------------------------------------------------------------------
+
+  function render(normalized) {
+    var config = DESTINATIONS[normalized];
+    if (!config) { return; }
+
+    // Require pageEl from netescape.js via the window-level navigate() caller.
+    // We reach pageEl through the netescape chrome — find it in the live DOM.
+    var pageEl = document.querySelector('.netescape-chrome__page');
+    if (!pageEl) { return; }
+
+    var statusEl = document.querySelector('.netescape-chrome__status-text');
+
+    // Always clean up any previous destination render before starting a new one.
+    cleanup();
+    pageEl.innerHTML = '';
+
+    var t = window.APC.timing;
+
+    // Status bar: "Connecting to [domain]..."
+    if (statusEl) { statusEl.textContent = 'Connecting to ' + normalized + '...'; }
+
+    if (config.screenshot === null) {
+      // --- Napster special case ---
+      // No audio. No canvas. Silence, then the court notice.
+      renderNapster(pageEl, statusEl, t);
+    } else {
+      // --- Standard scan-reveal ---
+      renderScanReveal(normalized, config, pageEl, statusEl, t);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // renderNapster — white page, court notice, no audio, no canvas.
+  // ---------------------------------------------------------------------------
+
+  function renderNapster(pageEl, statusEl, t) {
+    // Wait DESTINATIONS_STATUS_CONNECTING_MS, then DESTINATIONS_NAPSTER_PAUSE_MS,
+    // then render the notice. Total silence before text appears.
+    setTimeout(function () {
+      setTimeout(function () {
+        if (statusEl) { statusEl.textContent = 'Done'; }
+
+        var notice = document.createElement('div');
+        notice.className = 'netescape-napster-notice';
+        notice.setAttribute('role', 'main');
+        notice.setAttribute('aria-label', 'Napster shutdown notice');
+
+        var p = document.createElement('p');
+        p.textContent =
+          'NOTICE: On July 11, 2001, the Ninth Circuit Court of Appeals ' +
+          'affirmed the preliminary injunction against Napster, Inc. ' +
+          'As required by court order, Napster has been shut down. ' +
+          'Napster has been working diligently to comply with the court order. ' +
+          'The Napster service has been suspended effective today.';
+        notice.appendChild(p);
+
+        // Page el already cleared by render() before this call.
+        pageEl.appendChild(notice);
+
+        if (window.umami) {
+          window.umami.track('destination_navigate', { domain: 'napster.com', type: 'napster' });
+        }
+      }, t.DESTINATIONS_NAPSTER_PAUSE_MS);
+    }, t.DESTINATIONS_STATUS_CONNECTING_MS);
+  }
+
+  // ---------------------------------------------------------------------------
+  // renderScanReveal — canvas-based top-to-bottom progressive reveal.
+  // ---------------------------------------------------------------------------
+
+  function renderScanReveal(normalized, config, pageEl, statusEl, t) {
+    setTimeout(function () {
+      // Load the screenshot image.
+      var img = new Image();
+
+      img.onerror = function () {
+        // Graceful degradation: show plain error text, never crash.
+        if (statusEl) { statusEl.textContent = 'Error'; }
+        var errEl = document.createElement('p');
+        errEl.textContent = 'Could not load page.';
+        pageEl.innerHTML = '';
+        pageEl.appendChild(errEl);
+      };
+
+      img.onload = function () {
+        // Canvas sized to pageEl width; height preserves image aspect ratio.
+        var canvasWidth = pageEl.clientWidth || 680;
+        var scale = canvasWidth / img.naturalWidth;
+        var canvasHeight = Math.round(img.naturalHeight * scale);
+
+        var canvas = document.createElement('canvas');
+        canvas.width = canvasWidth;
+        canvas.height = canvasHeight;
+        canvas.style.display = 'block';
+        canvas.style.width = canvasWidth + 'px';
+        canvas.setAttribute('aria-label', config.label + ' — 2001 screenshot');
+        canvas.setAttribute('role', 'img');
+
+        // Mount canvas into pageEl before reveal starts.
+        pageEl.innerHTML = '';
+        pageEl.appendChild(canvas);
+        activeCanvas = canvas;
+
+        var ctx = canvas.getContext('2d');
+        var revealY = 0;
+
+        // Play modem audio at reveal start.
+        try {
+          modemAudio.currentTime = 0;
+          modemAudio.play().catch(function () {});
+        } catch (e) {}
+
+        if (statusEl) { statusEl.textContent = 'Loading ' + normalized + '...'; }
+
+        // Scan-reveal: each tick draws a band of random height from the current y position.
+        revealTimer = setInterval(function () {
+          if (revealY >= canvasHeight) {
+            // Reveal complete.
+            clearInterval(revealTimer);
+            revealTimer = null;
+
+            modemAudio.pause();
+            modemAudio.currentTime = 0;
+
+            if (statusEl) { statusEl.textContent = 'Done'; }
+
+            // Draw any remaining pixels (ensure full image is visible).
+            ctx.drawImage(img, 0, 0, canvasWidth, canvasHeight);
+
+            // Attach click-anywhere error dialog.
+            attachClickDialog(canvas, normalized, statusEl);
+
+            if (window.umami) {
+              window.umami.track('destination_navigate', { domain: normalized, type: 'destination' });
+            }
+            return;
+          }
+
+          // Random strip height for this tick.
+          var stripH = t.rand(t.DESTINATIONS_REVEAL_STRIP_MIN_PX, t.DESTINATIONS_REVEAL_STRIP_MAX_PX);
+          // Clamp so we never overdraw past the bottom.
+          if (revealY + stripH > canvasHeight) { stripH = canvasHeight - revealY; }
+
+          // Draw the corresponding slice of the source image.
+          // Source rect: full width, stripH px tall, from y = revealY (scaled back to image coords).
+          var srcY = Math.round(revealY / scale);
+          var srcH = Math.round(stripH / scale);
+          ctx.drawImage(
+            img,
+            0, srcY, img.naturalWidth, srcH,  // source rect
+            0, revealY, canvasWidth, stripH    // dest rect
+          );
+
+          revealY += stripH;
+        }, t.DESTINATIONS_REVEAL_INTERVAL_MS);
+      };
+
+      img.src = config.screenshot;
+
+    }, t.DESTINATIONS_STATUS_CONNECTING_MS);
+  }
+
+  // ---------------------------------------------------------------------------
+  // attachClickDialog — adds the click-anywhere error dialog to the canvas.
+  // Only attached after reveal completes — no clicks during reveal.
+  // Uses existing netescape-freeze-dialog CSS classes (no new CSS).
+  // ---------------------------------------------------------------------------
+
+  function attachClickDialog(canvas, normalized, statusEl) {
+    clickListener = function () {
+      showDestinationDialog(canvas, normalized);
+    };
+    canvas.style.cursor = 'default';
+    canvas.addEventListener('click', clickListener);
+  }
+
+  function showDestinationDialog(canvas, normalized) {
+    // Remove click listener to prevent double-dialog.
+    if (clickListener) {
+      canvas.removeEventListener('click', clickListener);
+      clickListener = null;
+    }
+
+    // Find chrome container — dialog is appended inside the chrome, not body.
+    var container = canvas.parentNode ? canvas.parentNode.parentNode : document.body;
+
+    var overlay = document.createElement('div');
+    overlay.className = 'netescape-freeze-dialog';
+    overlay.setAttribute('role', 'alertdialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-labelledby', 'dest-dialog-msg');
+
+    var win = document.createElement('div');
+    win.className = 'netescape-freeze-dialog__win';
+
+    var titlebar = document.createElement('div');
+    titlebar.className = 'netescape-freeze-dialog__titlebar';
+    var titleSpan = document.createElement('span');
+    titleSpan.className = 'netescape-freeze-dialog__title';
+    titleSpan.textContent = 'NetEscape';
+    titlebar.appendChild(titleSpan);
+    win.appendChild(titlebar);
+
+    var body = document.createElement('div');
+    body.className = 'netescape-freeze-dialog__body';
+
+    var icon = document.createElement('span');
+    icon.className = 'netescape-freeze-dialog__icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '\u26A0'; // ⚠
+
+    var msg = document.createElement('p');
+    msg.className = 'netescape-freeze-dialog__msg';
+    msg.id = 'dest-dialog-msg';
+    msg.textContent =
+      'This page cannot be displayed \u2014 ahisaka.com is a selective recreation. ' +
+      'Screenshots are provided for historical authenticity. ' +
+      'Full navigation is not available.';
+
+    body.appendChild(icon);
+    body.appendChild(msg);
+    win.appendChild(body);
+
+    var footer = document.createElement('div');
+    footer.className = 'netescape-freeze-dialog__footer';
+
+    var okBtn = document.createElement('button');
+    okBtn.className = 'win98-button netescape-freeze-dialog__btn';
+    okBtn.textContent = 'OK';
+
+    footer.appendChild(okBtn);
+    win.appendChild(footer);
+    overlay.appendChild(win);
+    container.appendChild(overlay);
+
+    okBtn.focus();
+
+    function close() {
+      if (overlay.parentNode) { overlay.parentNode.removeChild(overlay); }
+      // Re-attach click listener so subsequent clicks show the dialog again.
+      if (activeCanvas) {
+        clickListener = function () {
+          showDestinationDialog(activeCanvas, normalized);
+        };
+        activeCanvas.addEventListener('click', clickListener);
+      }
+      if (window.umami) {
+        window.umami.track('destination_screenshot_dismiss', { domain: normalized });
+      }
+    }
+
+    okBtn.addEventListener('click', close);
+
+    overlay.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' || e.key === 'Enter') { close(); }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  window.APC = window.APC || {};
+  window.APC.neDestinations = {
+    isDestination: isDestination,
+    render: render,
+    cleanup: cleanup
+  };
+
+}());

--- a/js/netescape.js
+++ b/js/netescape.js
@@ -65,9 +65,9 @@ window.APC.netescape = (function () {
   const dialupAudio = new Audio('assets/audio/dialup.mp3');
   dialupAudio.preload = 'auto';
   dialupAudio.addEventListener('error', function () {});
-  let pageEl = null;          // .ie-chrome__page element (scroll container)
+  let pageEl = null;          // .netescape-chrome__page element (scroll container)
   let addressInput = null;    // address bar <input>
-  let statusEl = null;        // .ie-chrome__status-text span
+  let statusEl = null;        // .netescape-chrome__status-text span
 
   // Navigation history stack
   let navHistory = [];        // array of normalized URL strings in visit order
@@ -148,6 +148,8 @@ window.APC.netescape = (function () {
         fwdBtn = null;
         navHistory = [];
         navIndex = -1;
+        // Clean up any in-flight destination render.
+        if (window.APC.neDestinations) { window.APC.neDestinations.cleanup(); }
       });
     }
 
@@ -199,12 +201,17 @@ window.APC.netescape = (function () {
     menubar.setAttribute('role', 'menubar');
     menubar.setAttribute('aria-label', 'Menu bar');
 
-    // Stub menu items — no dropdowns in MVP.
+    // Stub menu items — Favorites click renders the Favorites page.
     ['File', 'Edit', 'View', 'Go', 'Favorites', 'Help'].forEach(function (label) {
       const btn = document.createElement('button');
       btn.className = 'netescape-chrome__menu-item';
       btn.textContent = label;
       btn.setAttribute('role', 'menuitem');
+      if (label === 'Favorites') {
+        btn.addEventListener('click', function () {
+          renderFavorites();
+        });
+      }
       menubar.appendChild(btn);
     });
 
@@ -398,18 +405,34 @@ window.APC.netescape = (function () {
     // Cancel any in-flight partial-load freeze (user navigated away before dialog showed).
     if (freezeTimer) { clearTimeout(freezeTimer); freezeTimer = null; }
 
+    // Cancel any in-flight destination render.
+    if (window.APC.neDestinations) { window.APC.neDestinations.cleanup(); }
+
     // Resolve to page key; undefined = unknown / external URL.
     const pageKey = PAGE_ROUTES[normalized];
 
     // Track manual URL bar entries for analytics.
     if (fromUserInput && window.umami) {
-      window.umami.track('dialup_url_entry');
+      const isDestination = window.APC.neDestinations &&
+        window.APC.neDestinations.isDestination(normalized);
+      window.umami.track('dialup_url_entry', {
+        domain: normalized,
+        type: isDestination ? 'destination' : (pageKey ? 'internal' : 'unknown')
+      });
     }
 
     // Connection check: show no-connection page until the user dials up.
     // Once isConnected is true for the session, all navigations go direct.
     if (!window.APC.session.isConnected) {
       renderNoConnection();
+      return;
+    }
+
+    // Destination intercept: check before renderPartialLoad().
+    // If this URL is a recognized curated destination, hand off to the destinations
+    // module and return. No other changes to navigate() are needed.
+    if (window.APC.neDestinations && window.APC.neDestinations.isDestination(normalized)) {
+      window.APC.neDestinations.render(normalized);
       return;
     }
 
@@ -498,6 +521,116 @@ window.APC.netescape = (function () {
       if (hist.length > 10) { hist = hist.slice(0, 10); }
       sessionStorage.setItem('ne_history', JSON.stringify(hist));
     } catch (e) {}
+  }
+
+  // --- Favorites page --------------------------------------------------
+
+  // renderFavorites — renders all curated destinations grouped by folder in pageEl.
+  // Fired when the Favorites menubar button is clicked.
+  // Pattern: replaces pageEl content (same as renderHome, renderAbout, etc.).
+
+  function renderFavorites() {
+    if (!pageEl) { return; }
+    if (!window.APC.neDestinations) { return; }
+
+    // Clean up any in-flight destination render.
+    window.APC.neDestinations.cleanup();
+    pageEl.innerHTML = '';
+    if (statusEl) { statusEl.textContent = 'Done'; }
+
+    if (window.umami) { window.umami.track('favorites_open'); }
+
+    var DESTINATIONS = window.APC.neDestinations.getDestinations
+      ? window.APC.neDestinations.getDestinations()
+      : null;
+
+    // If getDestinations() not available (pre-Phase 2 scaffold), show placeholder.
+    if (!DESTINATIONS) {
+      var ph = document.createElement('p');
+      ph.textContent = 'Favorites not available.';
+      pageEl.appendChild(ph);
+      return;
+    }
+
+    var page = document.createElement('div');
+    page.className = 'netescape-favorites';
+
+    var title = document.createElement('p');
+    title.className = 'netescape-favorites__title';
+    title.textContent = '[ FAVORITES ]';
+    page.appendChild(title);
+
+    // Group destinations by folder.
+    var folders = [
+      { key: 'games',      label: '[ GAMES ]'      },
+      { key: 'cartoons',   label: '[ CARTOONS ]'   },
+      { key: 'sports',     label: '[ SPORTS ]'     },
+      { key: 'cool-stuff', label: '[ COOL STUFF ]' }
+    ];
+
+    folders.forEach(function (folder) {
+      var items = Object.keys(DESTINATIONS).filter(function (url) {
+        return DESTINATIONS[url].folder === folder.key;
+      });
+      if (items.length === 0) { return; }
+
+      var section = document.createElement('div');
+      section.className = 'netescape-favorites__section';
+
+      var heading = document.createElement('p');
+      heading.className = 'netescape-favorites__folder';
+      heading.textContent = folder.label;
+      section.appendChild(heading);
+
+      items.forEach(function (url) {
+        var dest = DESTINATIONS[url];
+        var link = document.createElement('a');
+        link.className = 'netescape-favorites__link';
+        link.href = '#';
+        link.textContent = '» ' + dest.label;
+        link.addEventListener('click', function (e) {
+          e.preventDefault();
+          navigate(url, false);
+        });
+        section.appendChild(link);
+        section.appendChild(document.createElement('br'));
+      });
+
+      page.appendChild(section);
+    });
+
+    // Separator before root-level bookmarks.
+    var sep = document.createElement('hr');
+    sep.className = 'netescape-favorites__sep';
+    sep.setAttribute('aria-hidden', 'true');
+    page.appendChild(sep);
+
+    // Root-level bookmarks (folder === null), Napster last.
+    var rootItems = Object.keys(DESTINATIONS).filter(function (url) {
+      return DESTINATIONS[url].folder === null && url !== 'napster.com';
+    });
+    var napsterItems = Object.keys(DESTINATIONS).filter(function (url) {
+      return url === 'napster.com';
+    });
+
+    rootItems.concat(napsterItems).forEach(function (url) {
+      var dest = DESTINATIONS[url];
+      var link = document.createElement('a');
+      link.className = 'netescape-favorites__link';
+      if (url === 'napster.com') {
+        link.className += ' netescape-favorites__link--napster';
+      }
+      link.href = '#';
+      link.textContent = '» ' + dest.label;
+      link.addEventListener('click', function (e) {
+        e.preventDefault();
+        navigate(url, false);
+      });
+      page.appendChild(link);
+      page.appendChild(document.createElement('br'));
+    });
+
+    pageEl.appendChild(page);
   }
 
   function renderHome() {
@@ -637,7 +770,7 @@ window.APC.netescape = (function () {
 
     const underConst = document.createElement('p');
     underConst.className = 'netescape-about__under-construction';
-    underConst.textContent = '🚧 UNDER CONSTRUCTION 🚧';
+    underConst.textContent = '\ud83d\udea7 UNDER CONSTRUCTION \ud83d\udea7';
 
     topHeader.appendChild(h1);
     topHeader.appendChild(underConst);
@@ -1541,7 +1674,7 @@ window.APC.netescape = (function () {
     const icon = document.createElement('div');
     icon.className = 'dialup-modal__icon';
     icon.setAttribute('aria-hidden', 'true');
-    icon.textContent = '📞';
+    icon.textContent = '\ud83d\udcde';
 
     const phoneNum = document.createElement('p');
     phoneNum.className = 'dialup-modal__phone';
@@ -1651,6 +1784,7 @@ window.APC.netescape = (function () {
     if (freezeTimer)    { clearTimeout(freezeTimer);    freezeTimer = null;    }
     if (pageLoadTimer)  { clearTimeout(pageLoadTimer);  pageLoadTimer = null;  }
     if (pageLoadMidTimer) { clearTimeout(pageLoadMidTimer); pageLoadMidTimer = null; }
+    if (window.APC.neDestinations) { window.APC.neDestinations.cleanup(); }
   }
 
   // --- Public exports --------------------------------------------------

--- a/js/win98-timing.js
+++ b/js/win98-timing.js
@@ -2,7 +2,7 @@
 // Centralised timing token system for the WinDoors 98 behavioral fidelity simulation.
 //
 // Every delay value in this project lives here. Never hardcode ms values elsewhere —
-// always reference window.APC.timing.<TOKEN>.
+// always reference window.APC.timing.<token>.
 //
 // Grounded in IBM Aptiva SE7 hardware (1998) on a V.90 56K modem at ~30 kbps actual
 // throughput. When validating a delay, ask: "Would this be noticeable on an IBM Aptiva
@@ -102,6 +102,18 @@
     NE_MANUAL_URL_MIN_MS:    1000,  // manual URL entry (dial-up simulation delay)
     NE_MANUAL_URL_MAX_MS:    4000,
     NE_FREEZE_DELAY_MS:      2500,  // unknown URL: stub renders then freezes before dialog
+
+    // -------------------------------------------------------------------------
+    // NetEscape Destinations  —  PROTECTED PATH
+    // Canvas scan-reveal of 2001-era Wayback Machine screenshots.
+    // All destination navigations are Protected Path — no failures, no crashes.
+    // -------------------------------------------------------------------------
+
+    DESTINATIONS_REVEAL_STRIP_MIN_PX:   4,  // min height (px) of each reveal band per tick
+    DESTINATIONS_REVEAL_STRIP_MAX_PX:  16,  // max height (px) of each reveal band per tick
+    DESTINATIONS_REVEAL_INTERVAL_MS:   16,  // setInterval tick rate for scan-reveal (≈60fps)
+    DESTINATIONS_STATUS_CONNECTING_MS: 800, // status bar "Connecting..." delay before reveal starts
+    DESTINATIONS_NAPSTER_PAUSE_MS:    1200, // extra pause after connecting before Napster notice renders
 
     // -------------------------------------------------------------------------
     ICON_HINT_DELAY_MS:   1200,  // wait after single click before hint appears


### PR DESCRIPTION
# NetEscape Curated Destinations

Implements the full PRD for curated 2001-era internet destinations inside NetEscape Navigator.

## What's in this PR

### New file: `js/apps/netescape-destinations.js`
- IIFE module, exports `window.APC.neDestinations = { isDestination, render, cleanup }`
- Full `DESTINATIONS` map — 18 entries (17 destinations + Napster special case)
- Canvas scan-reveal renderer: top-to-bottom horizontal band reveal, randomized strip height per tick (4–16px), 16ms interval
- Modem handshake audio: single preloaded `Audio` object, plays at reveal start, stops on complete
- Click-anywhere error dialog after reveal completes — reuses existing `netescape-freeze-dialog` CSS classes, no new CSS
- Napster special case: no canvas, no audio, white page with verbatim July 2001 RIAA court shutdown notice
- `cleanup()`: clears reveal timer, stops audio, removes click listener — safe to call when nothing is active

### Modified: `js/win98-timing.js`
5 new timing tokens under `// NetEscape Destinations — PROTECTED PATH`:
- `DESTINATIONS_REVEAL_STRIP_MIN_PX: 4`
- `DESTINATIONS_REVEAL_STRIP_MAX_PX: 16`
- `DESTINATIONS_REVEAL_INTERVAL_MS: 16`
- `DESTINATIONS_STATUS_CONNECTING_MS: 800`
- `DESTINATIONS_NAPSTER_PAUSE_MS: 1200`

### Modified: `js/netescape.js`
- Destination intercept in `navigate()`: single `if`-block after `isConnected` check, before `renderPartialLoad()`. Calls `window.APC.neDestinations.render(normalized)` and returns.
- `cleanup()` called at top of `navigate()` and in `reset()` and window close handler
- Favorites menubar button wired to `renderFavorites()`
- `renderFavorites()`: renders all destinations grouped by folder in `pageEl`. Napster appears last below a separator. Fires `favorites_open` Umami event.
- Improved `dialup_url_entry` Umami event now includes `domain` and `type` (`destination` / `internal` / `unknown`)

### Modified: `index.html`
- `<script src="js/apps/netescape-destinations.js">` added after `netescape.js`

## What's NOT in this PR
- Screenshot assets (`assets/destinations/*.jpg`) — Atsushi captures these manually per the Phase 1 protocol in the PRD
- `assets/audio/modem-handshake.mp3` — Atsushi sources and commits independently
- New CSS — all dialogs reuse existing `netescape-freeze-dialog` classes

## QA checklist (run locally before merging)
- [ ] `ahisaka.com`, `ahisaka.com/about`, `ahisaka.com/thoughts`, `ahisaka.com/projects`, `ahisaka.com/guestbook` all load correctly — zero regression
- [ ] Typing `miniclip.com` in address bar hits destination intercept (console log or status bar confirms)
- [ ] Favorites button click renders the Favorites page with all folder sections
- [ ] All 17 destination links in Favorites are clickable and call `navigate()`
- [ ] Napster shows no audio and no canvas — only the court notice after the pause
- [ ] Navigating away mid-reveal (type new URL) cleanly cancels the reveal and audio
- [ ] Screenshot image 404 shows "Could not load page." gracefully, no crash
- [ ] Click on revealed screenshot shows the error dialog; OK dismisses it

## Assets still needed before full feature is live
Once screenshots and audio are committed to this branch, the feature is production-ready.

Screenshot capture protocol: `web.archive.org/web/2001*/http://[domain]` → pick 2001 snapshot → hide Wayback toolbar (`document.querySelector('#wm-ipp-base').style.display='none'`) → full-page screenshot → resize to 680px wide → JPG quality 85 → save to `assets/destinations/[filename].jpg`