### PR TITLE
fix: allow Umami event collection in CSP

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -150,3 +150,14 @@ and should not be updated to include it.
 **Do not** add `static.cloudflareinsights.com` to `script-src` in the Caddyfile.
 If you see a CSP console error for this domain, re-disable RUM in the Cloudflare dashboard
 (it may have been re-enabled by a Cloudflare setting change) — do not fix it via CSP.
+
+## Umami CSP Requirement
+
+Umami Cloud loads its script from `https://cloud.umami.is`, but event collection posts to `https://api-gateway.umami.dev/api/send`.
+
+The Caddy Content-Security-Policy must allow both:
+- `script-src https://cloud.umami.is`
+- `connect-src https://api-gateway.umami.dev`
+
+If `connect-src` is missing, `window.umami` may exist but events will not reach Umami.
+

--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -7,7 +7,7 @@
     root * /home/atsushi/site
     file_server
 
-    header Content-Security-Policy "script-src 'self' 'unsafe-inline' https://cloud.umami.is https://cdn.jsdelivr.net"
+    header Content-Security-Policy "script-src 'self' 'unsafe-inline' https://cloud.umami.is https://cdn.jsdelivr.net; connect-src 'self' https://api-gateway.umami.dev"
 
     header /js/* Cache-Control "no-cache, must-revalidate"
     header /css/* Cache-Control "no-cache, must-revalidate"


### PR DESCRIPTION
## Summary

Fixes Umami event collection by allowing event POSTs to the Umami API gateway.

The Umami script loads from `https://cloud.umami.is`, but events are sent to `https://api-gateway.umami.dev/api/send`. The previous CSP allowed the script source but did not explicitly allow the connection target.

## Changes

- Adds `connect-src 'self' https://api-gateway.umami.dev` to `config/Caddyfile`
- Documents the Umami CSP requirement in `config/CLAUDE.md`

## Manual QA

- `caddy validate --config config/Caddyfile` passes
- Reloaded Caddy successfully
- `window.umami.track('manual_test')` resolves in browser console
- Network request reaches `https://api-gateway.umami.dev/api/send`
